### PR TITLE
feat: add option to disable local login

### DIFF
--- a/services/web/app/src/Features/Authentication/AuthenticationController.mjs
+++ b/services/web/app/src/Features/Authentication/AuthenticationController.mjs
@@ -26,6 +26,7 @@ import { expressify, promisify } from '@overleaf/promise-utils'
 import { handleAuthenticateErrors } from './AuthenticationErrors.mjs'
 import EmailHelper from '../Helpers/EmailHelper.mjs'
 import SplitTestHandler from '../SplitTests/SplitTestHandler.mjs'
+import Features from '../../infrastructure/Features.mjs'
 
 const { hasAdminAccess } = AdminAuthorizationHelper
 
@@ -124,6 +125,15 @@ const AuthenticationController = {
   },
 
   passportLogin(req, res, next) {
+    if (Features.localLoginDisabled()) {
+      return res.status(403).json({
+        message: {
+          type: 'error',
+          text: 'Local login is disabled. Please use an external identity provider.',
+        },
+      })
+    }
+
     // This function is middleware which wraps the passport.authenticate middleware,
     // so we can send back our custom `{message: {text: "", type: ""}}` responses on failure,
     // and send a `{redir: ""}` response on success

--- a/services/web/app/src/Features/User/UserPagesController.mjs
+++ b/services/web/app/src/Features/User/UserPagesController.mjs
@@ -276,6 +276,7 @@ const UserPagesController = {
       title: Settings.nav?.login_support_title || 'login',
       login_support_title: Settings.nav?.login_support_title,
       login_support_text: Settings.nav?.login_support_text,
+      localLoginDisabled: Features.localLoginDisabled(),
       metadata,
     })
   },

--- a/services/web/app/src/infrastructure/Features.mjs
+++ b/services/web/app/src/infrastructure/Features.mjs
@@ -34,7 +34,15 @@ const Features = {
     return (
       (Boolean(Settings.ldap) && Boolean(Settings.ldap.enable)) ||
       (Boolean(Settings.saml) && Boolean(Settings.saml.enable)) ||
+      (Boolean(Settings.oidc) && Boolean(Settings.oidc.enable)) ||
       Boolean(Settings.overleaf)
+    )
+  },
+
+  localLoginDisabled() {
+    return (
+      Boolean(Settings.disableLocalLogin) &&
+      Features.externalAuthenticationSystemUsed()
     )
   },
 

--- a/services/web/app/views/user/login.pug
+++ b/services/web/app/views/user/login.pug
@@ -13,37 +13,68 @@ block content
 							h1 !{login_support_title}
 						else
 							h1 #{translate("log_in")} 
-					form(name='loginForm' data-ol-async-form action='/login' method='POST')
-						input(name='_csrf' type='hidden' value=csrfToken)
-						+formMessagesNewStyle
-						+customFormMessageNewStyle('invalid-password-retry-or-reset', 'danger')
-							| !{translate('email_or_password_wrong_try_again_or_reset', {}, [{ name: 'a', attrs: { href: '/user/password/reset', 'aria-describedby': 'resetPasswordDescription' } }])}
-							span.visually-hidden(id='resetPasswordDescription')
-								| #{translate('reset_password_link')}
-						+customFormMessageNewStyle('password-compromised')
-							| !{translate('password_compromised_try_again_or_use_known_device_or_reset', {}, [{name: 'a', attrs: {href: 'https://haveibeenpwned.com/passwords', rel: 'noopener noreferrer', target: '_blank'}}, {name: 'a', attrs: {href: '/user/password/reset', target: '_blank'}}])}.
-						.form-group
-							label(for='email') #{translate("email")}
-							input#email.form-control(
-								name='email'
-								type='email'
-								required
-								autofocus='true'
-								autocomplete='username'
+					if !localLoginDisabled
+						form(name='loginForm' data-ol-async-form action='/login' method='POST')
+							input(name='_csrf' type='hidden' value=csrfToken)
+							+formMessagesNewStyle
+							+customFormMessageNewStyle('invalid-password-retry-or-reset', 'danger')
+								| !{translate('email_or_password_wrong_try_again_or_reset', {}, [{ name: 'a', attrs: { href: '/user/password/reset', 'aria-describedby': 'resetPasswordDescription' } }])}
+								span.visually-hidden(id='resetPasswordDescription')
+									| #{translate('reset_password_link')}
+							+customFormMessageNewStyle('password-compromised')
+								| !{translate('password_compromised_try_again_or_use_known_device_or_reset', {}, [{name: 'a', attrs: {href: 'https://haveibeenpwned.com/passwords', rel: 'noopener noreferrer', target: '_blank'}}, {name: 'a', attrs: {href: '/user/password/reset', target: '_blank'}}])}.
+							.form-group
+								label(for='email') #{translate("email")}
+								input#email.form-control(
+									name='email'
+									type='email'
+									required
+									autofocus='true'
+									autocomplete='username'
+								)
+							.form-group
+								label(for='password') #{translate("password")}
+								input#password.form-control(
+									name='password'
+									type='password'
+									autocomplete='current-password'
+									required
+								)
+							.actions
+								button.btn-primary.btn(type='submit' data-ol-disabled-inflight)
+									span(data-ol-inflight='idle') #{translate("login")}
+									span(hidden data-ol-inflight='pending') #{translate("logging_in")}…
+								a.float-end(href='/user/password/reset') #{translate("forgot_your_password")}?
+					if !localLoginDisabled && ((settings.ldap && settings.ldap.enable) || (settings.saml && settings.saml.enable) || (settings.oidc && settings.oidc.enable))
+						p.ciam-login-register-or-text-container
+							span.ciam-login-register-or-text #{translate("or")}
+					if settings.ldap && settings.ldap.enable
+						.actions(style='margin-top: 15px;')
+							a.button.btn-secondary.btn(
+								href='/ldap/login',
+								style="width: 100%;"
+								data-ol-disabled-inflight
 							)
-						.form-group
-							label(for='password') #{translate("password")}
-							input#password.form-control(
-								name='password'
-								type='password'
-								autocomplete='current-password'
-								required
+								span(data-ol-inflight="idle") #{settings.ldap.identityServiceName}
+								span(hidden data-ol-inflight="pending") #{translate("logging_in")}…
+					if settings.saml && settings.saml.enable
+						.actions(style='margin-top: 15px;')
+							a.button.btn-secondary.btn(
+								href='/saml/login',
+								style="width: 100%;"
+								data-ol-disabled-inflight
 							)
-						.actions
-							button.btn-primary.btn(type='submit' data-ol-disabled-inflight)
-								span(data-ol-inflight='idle') #{translate("login")}
-								span(hidden data-ol-inflight='pending') #{translate("logging_in")}…
-							a.float-end(href='/user/password/reset') #{translate("forgot_your_password")}?
-						if login_support_text
-							hr
-							p.text-center !{login_support_text}
+								span(data-ol-inflight="idle") #{settings.saml.identityServiceName}
+								span(hidden data-ol-inflight="pending") #{translate("logging_in")}…
+					if settings.oidc && settings.oidc.enable
+						.actions(style='margin-top: 15px;')
+							a.button.btn-secondary.btn(
+								href='/oidc/login',
+								style="width: 100%;"
+								data-ol-disabled-inflight
+							)
+								span(data-ol-inflight="idle") #{settings.oidc.identityServiceName}
+								span(hidden data-ol-inflight="pending") #{translate("logging_in")}…
+					if login_support_text
+						hr
+						p.text-center !{login_support_text}

--- a/services/web/config/settings.defaults.js
+++ b/services/web/config/settings.defaults.js
@@ -1257,6 +1257,7 @@ module.exports = {
   },
   enableGitBridge: process.env.GIT_BRIDGE_ENABLED === 'true',
   enableGithubSync: process.env.GITHUB_SYNC_ENABLED === 'true',
+  disableLocalLogin: process.env.OVERLEAF_DISABLE_LOCAL_LOGIN === 'true',
   unsupportedBrowsers: {
     ie: '<=11',
     safari: '<15',

--- a/services/web/modules/login-register/app/src/LoginController.mjs
+++ b/services/web/modules/login-register/app/src/LoginController.mjs
@@ -1,5 +1,6 @@
 import AuthenticationController from "../../../../app/src/Features/Authentication/AuthenticationController.mjs"
 import Settings from "@overleaf/settings"
+import Features from '../../../../app/src/infrastructure/Features.mjs'
 import Path from 'path'
 
 export default {
@@ -22,6 +23,7 @@ export default {
       title: Settings.nav?.login_support_title || 'login',
       login_support_title: Settings.nav?.login_support_title,
       login_support_text: Settings.nav?.login_support_text,
+      localLoginDisabled: Features.localLoginDisabled(),
       metadata,
     })
   },
@@ -45,6 +47,7 @@ export default {
       title: Settings.nav?.login_support_title || 'login',
       login_support_title: Settings.nav?.login_support_title,
       login_support_text: Settings.nav?.login_support_text,
+      localLoginDisabled: Features.localLoginDisabled(),
       metadata,
     })
   }

--- a/services/web/modules/login-register/app/views/user/login.pug
+++ b/services/web/modules/login-register/app/views/user/login.pug
@@ -16,48 +16,49 @@ block content
 								else
 									h1.h3 #{translate("log_in")}
 							.login-register-hr-text-container(style='margin-top: 1px; padding: 5px 0;')
-							form(name='loginForm' data-ol-async-form action='/login' method='POST')
-								input(name='_csrf' type='hidden' value=csrfToken)
-								+formMessagesNewStyle
-								+customFormMessageNewStyle('invalid-password-retry-or-reset', 'danger')
-									| !{translate('email_or_password_wrong_try_again_or_reset', {}, [{ name: 'a', attrs: { href: '/user/password/reset', 'aria-describedby': 'resetPasswordDescription' } }])}
-									span.visually-hidden(id='resetPasswordDescription')
-										| #{translate('reset_password_link')}
-								+customFormMessageNewStyle('password-compromised')
-									| !{translate('password_compromised_try_again_or_use_known_device_or_reset', {}, [{name: 'a', attrs: {href: 'https://haveibeenpwned.com/passwords', rel: 'noopener noreferrer', target: '_blank'}}, {name: 'a', attrs: {href: '/user/password/reset', target: '_blank'}}])}.
-								.form-group
-									label(for='email') #{translate("email")}
-									input#email.form-control(
-										name='email'
-										type='email'
-										required
-										placeholder='email@example.com'
-										autofocus='true'
-										autocomplete='username'
-									)
-								.form-group
-									label(for='password') #{translate("password")}
-									input#password.form-control(
-										name='password'
-										type='password'
-										autocomplete='current-password'
-										required
-									)
-								.actions
-									button.btn-primary.btn(type='submit' data-ol-disabled-inflight)
-										span(data-ol-inflight='idle') #{translate("login")}
-										span(hidden data-ol-inflight='pending') #{translate("logging_in")}…
-									a.float-end(href='/user/password/reset') #{translate("forgot_your_password")}?
-								if login_support_text
-									hr
-									p.text-center !{login_support_text}
-							if (settings.ldap && settings.ldap.enable) || (settings.saml && settings.saml.enable) || (settings.oidc && settings.oidc.enable)
+							if !localLoginDisabled
+								form(name='loginForm' data-ol-async-form action='/login' method='POST')
+									input(name='_csrf' type='hidden' value=csrfToken)
+									+formMessagesNewStyle
+									+customFormMessageNewStyle('invalid-password-retry-or-reset', 'danger')
+										| !{translate('email_or_password_wrong_try_again_or_reset', {}, [{ name: 'a', attrs: { href: '/user/password/reset', 'aria-describedby': 'resetPasswordDescription' } }])}
+										span.visually-hidden(id='resetPasswordDescription')
+											| #{translate('reset_password_link')}
+									+customFormMessageNewStyle('password-compromised')
+										| !{translate('password_compromised_try_again_or_use_known_device_or_reset', {}, [{name: 'a', attrs: {href: 'https://haveibeenpwned.com/passwords', rel: 'noopener noreferrer', target: '_blank'}}, {name: 'a', attrs: {href: '/user/password/reset', target: '_blank'}}])}.
+									.form-group
+										label(for='email') #{translate("email")}
+										input#email.form-control(
+											name='email'
+											type='email'
+											required
+											placeholder='email@example.com'
+											autofocus='true'
+											autocomplete='username'
+										)
+									.form-group
+										label(for='password') #{translate("password")}
+										input#password.form-control(
+											name='password'
+											type='password'
+											autocomplete='current-password'
+											required
+										)
+									.actions
+										button.btn-primary.btn(type='submit' data-ol-disabled-inflight)
+											span(data-ol-inflight='idle') #{translate("login")}
+											span(hidden data-ol-inflight='pending') #{translate("logging_in")}…
+										a.float-end(href='/user/password/reset') #{translate("forgot_your_password")}?
+									if login_support_text
+										hr
+										p.text-center !{login_support_text}
+							if !localLoginDisabled && ((settings.ldap && settings.ldap.enable) || (settings.saml && settings.saml.enable) || (settings.oidc && settings.oidc.enable))
 								p.ciam-login-register-or-text-container
 									span.ciam-login-register-or-text #{translate("or")}
 							if settings.ldap && settings.ldap.enable
 								.actions(style='margin-top: 15px;')
 									a.button.btn-secondary.btn(
-									href='/ldap/login',
+										href='/ldap/login',
 										style="width: 100%;"
 										data-ol-disabled-inflight
 									)
@@ -66,7 +67,7 @@ block content
 							if settings.saml && settings.saml.enable
 								.actions(style='margin-top: 15px;')
 									a.button.btn-secondary.btn(
-									href='/saml/login',
+										href='/saml/login',
 										style="width: 100%;"
 										data-ol-disabled-inflight
 									)

--- a/services/web/test/unit/src/infrastructure/Features.test.mjs
+++ b/services/web/test/unit/src/infrastructure/Features.test.mjs
@@ -34,6 +34,14 @@ describe('Features', function () {
         expect(ctx.Features.externalAuthenticationSystemUsed()).to.be.true
       })
     })
+    describe('with oidc setting', function () {
+      beforeEach(function (ctx) {
+        ctx.settings.oidc = { enable: true }
+      })
+      it('should return true', function (ctx) {
+        expect(ctx.Features.externalAuthenticationSystemUsed()).to.be.true
+      })
+    })
     describe('with oauth setting', function () {
       beforeEach(function (ctx) {
         ctx.settings.overleaf = { oauth: true }
@@ -41,6 +49,25 @@ describe('Features', function () {
       it('should return true', function (ctx) {
         expect(ctx.Features.externalAuthenticationSystemUsed()).to.be.true
       })
+    })
+  })
+
+  describe('localLoginDisabled', function () {
+    it('should return false by default', function (ctx) {
+      expect(ctx.Features.localLoginDisabled()).to.be.false
+    })
+
+    it('should return false when disabled without external auth', function (ctx) {
+      ctx.settings.disableLocalLogin = true
+
+      expect(ctx.Features.localLoginDisabled()).to.be.false
+    })
+
+    it('should return true when disabled with external auth', function (ctx) {
+      ctx.settings.disableLocalLogin = true
+      ctx.settings.oidc = { enable: true }
+
+      expect(ctx.Features.localLoginDisabled()).to.be.true
     })
   })
 


### PR DESCRIPTION
## Summary
- add OVERLEAF_DISABLE_LOCAL_LOGIN to hide the local login form when external auth is enabled
- keep configured LDAP/SAML/OIDC login buttons visible
- block direct POST /login attempts when local login is disabled
- include OIDC in external-auth feature detection and add unit coverage

## Testing
- git diff --check
- unit test command could not be completed locally because the workspace lockfile is missing @overleaf/linked-url-proxy@workspace:services/linked-url-proxy