### PR TITLE
feat: add configurable main color

### DIFF
--- a/services/web/app/src/infrastructure/ExpressLocals.mjs
+++ b/services/web/app/src/infrastructure/ExpressLocals.mjs
@@ -15,6 +15,7 @@ import AdminAuthorizationHelper from '../Features/Helpers/AdminAuthorizationHelp
 import { addOptionalCleanupHandlerAfterDrainingConnections } from './GracefulShutdown.mjs'
 import { sanitizeSessionUserForFrontEnd } from './FrontEndUser.mjs'
 import { expressify } from '@overleaf/promise-utils'
+import { buildMainColorCss } from './MainColor.mjs'
 
 const {
   canRedirectToAdminDomain,
@@ -324,6 +325,7 @@ export default async function (webRouter, privateApiRouter, publicApiRouter) {
 
   webRouter.use(function (req, res, next) {
     res.locals.settings = Settings
+    res.locals.mainColorCssVariables = buildMainColorCss(Settings.mainColor)
     next()
   })
 

--- a/services/web/app/src/infrastructure/MainColor.mjs
+++ b/services/web/app/src/infrastructure/MainColor.mjs
@@ -1,0 +1,98 @@
+const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
+
+export function normalizeMainColor(value) {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const color = value.trim()
+  if (!HEX_COLOR_REGEX.test(color)) {
+    return null
+  }
+
+  if (color.length === 4) {
+    const [, red, green, blue] = color
+    return `#${red}${red}${green}${green}${blue}${blue}`.toLowerCase()
+  }
+
+  return color.toLowerCase()
+}
+
+export function buildMainColorCss(value) {
+  const mainColor = normalizeMainColor(value)
+  if (!mainColor) {
+    return null
+  }
+
+  const palette = buildPalette(mainColor)
+
+  return `:root {
+  --ol-main-color: ${mainColor};
+  --green-10: ${palette[10]};
+  --green-20: ${palette[20]};
+  --green-30: ${palette[30]};
+  --green-40: ${palette[40]};
+  --green-50: ${palette[50]};
+  --green-60: ${palette[60]};
+  --green-70: ${palette[70]};
+  --green-bright: ${palette[50]};
+  --green-bright-tint-50: ${palette.brightTint50};
+  --bg-accent-01: var(--green-50);
+  --bg-accent-02: var(--green-60);
+  --bg-accent-03: var(--green-10);
+  --content-positive: var(--green-50);
+  --content-positive-dark: var(--green-40);
+  --link-web: var(--green-60);
+  --link-web-hover: var(--green-70);
+  --link-web-visited: var(--green-60);
+  --link-web-dark: var(--green-30);
+  --link-web-hover-dark: var(--green-40);
+  --link-web-visited-dark: var(--green-40);
+}`
+}
+
+function buildPalette(mainColor) {
+  return {
+    10: mix(mainColor, '#ffffff', 0.1),
+    20: mix(mainColor, '#ffffff', 0.3),
+    30: mix(mainColor, '#ffffff', 0.5),
+    40: mix(mainColor, '#ffffff', 0.7),
+    50: mainColor,
+    60: mix(mainColor, '#000000', 0.82),
+    70: mix(mainColor, '#000000', 0.66),
+    brightTint50: mix(mainColor, '#ffffff', 0.5),
+  }
+}
+
+function mix(color, backgroundColor, weight) {
+  const rgb = hexToRgb(color)
+  const backgroundRgb = hexToRgb(backgroundColor)
+
+  return rgbToHex({
+    red: mixChannel(rgb.red, backgroundRgb.red, weight),
+    green: mixChannel(rgb.green, backgroundRgb.green, weight),
+    blue: mixChannel(rgb.blue, backgroundRgb.blue, weight),
+  })
+}
+
+function mixChannel(value, backgroundValue, weight) {
+  return Math.round(value * weight + backgroundValue * (1 - weight))
+}
+
+function hexToRgb(color) {
+  const value = color.slice(1)
+
+  return {
+    red: parseInt(value.slice(0, 2), 16),
+    green: parseInt(value.slice(2, 4), 16),
+    blue: parseInt(value.slice(4, 6), 16),
+  }
+}
+
+function rgbToHex({ red, green, blue }) {
+  return `#${toHex(red)}${toHex(green)}${toHex(blue)}`
+}
+
+function toHex(value) {
+  return value.toString(16).padStart(2, '0')
+}

--- a/services/web/app/views/layout-base.pug
+++ b/services/web/app/views/layout-base.pug
@@ -24,6 +24,8 @@ html(
 		block css
 			each file in entrypointStyles(entrypoint)
 				link(rel='stylesheet' href=file)
+		if mainColorCssVariables
+			style(nonce=scriptNonce)!= mainColorCssVariables
 
 		block _headLinks
 

--- a/services/web/config/settings.defaults.js
+++ b/services/web/config/settings.defaults.js
@@ -820,6 +820,7 @@ module.exports = {
   },
 
   appName: process.env.APP_NAME || 'Overleaf (Community Edition)',
+  mainColor: process.env.OVERLEAF_MAIN_COLOR,
 
   adminEmail: process.env.ADMIN_EMAIL || 'placeholder@example.com',
   adminDomains: process.env.ADMIN_DOMAINS

--- a/services/web/test/unit/src/infrastructure/MainColor.test.mjs
+++ b/services/web/test/unit/src/infrastructure/MainColor.test.mjs
@@ -1,0 +1,39 @@
+import { expect } from 'vitest'
+import {
+  buildMainColorCss,
+  normalizeMainColor,
+} from '../../../../app/src/infrastructure/MainColor.mjs'
+
+describe('MainColor', function () {
+  describe('normalizeMainColor', function () {
+    it('normalizes six character hex colors', function () {
+      expect(normalizeMainColor(' #A1B2C3 ')).to.equal('#a1b2c3')
+    })
+
+    it('expands three character hex colors', function () {
+      expect(normalizeMainColor('#abc')).to.equal('#aabbcc')
+    })
+
+    it('rejects invalid values', function () {
+      expect(normalizeMainColor('red')).to.be.null
+      expect(normalizeMainColor('var(--green-50)')).to.be.null
+      expect(normalizeMainColor('#12345g')).to.be.null
+      expect(normalizeMainColor('}; body { display: none')).to.be.null
+    })
+  })
+
+  describe('buildMainColorCss', function () {
+    it('returns null when the color is invalid', function () {
+      expect(buildMainColorCss('red')).to.be.null
+    })
+
+    it('builds CSS custom property overrides from the main color', function () {
+      const css = buildMainColorCss('#123456')
+
+      expect(css).to.contain('--ol-main-color: #123456;')
+      expect(css).to.contain('--green-50: #123456;')
+      expect(css).to.contain('--bg-accent-01: var(--green-50);')
+      expect(css).to.contain('--link-web-hover: var(--green-70);')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add OVERLEAF_MAIN_COLOR to configure the main accent color at runtime
- Generate sanitized CSS custom-property overrides for the green/accent palette
- Inject the overrides through the base layout and add focused unit coverage

## Testing
- node --check services/web/app/src/infrastructure/MainColor.mjs
- node --input-type=module direct helper validation
- git diff --check

Note: yarn test:unit test/unit/src/infrastructure/MainColor.test.mjs is currently blocked by the existing lockfile error for @overleaf/linked-url-proxy@workspace:services/linked-url-proxy.