### PR TITLE
Feature: clsi cache to accelerate compile speed

### DIFF
--- a/develop/.gitignore
+++ b/develop/.gitignore
@@ -3,3 +3,4 @@
 .env
 output
 compiles
+clsi-cache

--- a/develop/dev.env
+++ b/develop/dev.env
@@ -99,3 +99,7 @@ HAVE_I_BEEN_PWNED_ENABLED=true
 #     Proxy     #
 #################
 LINKED_URL_PROXY_HOST=linked-url-proxy
+# clsi-cache: shared by web (lookups) and clsi (build notifications)
+CLSI_CACHE_INSTANCES=[{"url":"http://clsi-cache:3044","shard":"clsi-cache-dev"}]
+CLSI_CACHE_CURRENT_SHARDS=1
+CLSI_CACHE_DESIRED_SHARDS=1

--- a/develop/docker-compose.dev.yml
+++ b/develop/docker-compose.dev.yml
@@ -11,6 +11,17 @@ services:
       - ../services/clsi/config:/overleaf/services/clsi/config
       - ../services/clsi/seccomp:/overleaf/services/clsi/seccomp
 
+  clsi-cache:
+    command: ["node", "--watch", "app.js"]
+    environment:
+      - NODE_OPTIONS=--inspect=0.0.0.0:9229
+    ports:
+      - "127.0.0.1:9242:9229"
+    volumes:
+      - ../services/clsi-cache/app:/overleaf/services/clsi-cache/app
+      - ../services/clsi-cache/app.js:/overleaf/services/clsi-cache/app.js
+      - ../services/clsi-cache/config:/overleaf/services/clsi-cache/config
+
   chat:
     command: ["node", "--watch", "app.js"]
     environment:

--- a/develop/docker-compose.yml
+++ b/develop/docker-compose.yml
@@ -35,6 +35,21 @@ services:
       - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:/var/run/docker.sock
       - clsi-cache:/overleaf/services/clsi/cache
 
+  clsi-cache:
+    build:
+      context: ..
+      dockerfile: services/clsi-cache/Dockerfile
+    env_file:
+      - dev.env
+    environment:
+      - CLSI_CACHE_SHARD=clsi-cache-dev
+      # clsi's ${PWD}/output and the cache share one bind mount, so outputs
+      # can be hard-linked instead of downloaded.
+      - CLSI_CACHE_LOCAL_CLSI_OUTPUT_DIR=/overleaf/develop-data/output
+      - CLSI_CACHE_DATA_PATH=/overleaf/develop-data/clsi-cache
+    volumes:
+      - ${PWD}:/overleaf/develop-data
+
   clsi-nginx:
     image: nginx:1.28
     read_only: true

--- a/develop/webpack.config.dev-env.js
+++ b/develop/webpack.config.dev-env.js
@@ -20,6 +20,12 @@ module.exports = merge(base, {
         pathRewrite: { '^/git': '' }
       },
       {
+        // The clsi-cache lookup ends with .json and would otherwise be
+        // swallowed by the static-asset exclusion below.
+        context: '/project/**/output/cached/**',
+        target: 'http://web:3000',
+      },
+      {
         context: ['!**/*.js', '!**/*.css', '!**/*.json'],
         target: 'http://web:3000',
       },

--- a/server-ce/config/env.sh
+++ b/server-ce/config/env.sh
@@ -19,3 +19,18 @@ export WEB_API_HOST=127.0.0.1
 if [ "${SANDBOXED_COMPILES_SIBLING_CONTAINERS:-}" = "true" ]; then
   export TEXLIVE_IMAGE_USER=www-data
 fi
+# clsi-cache keeps the outputs of the last compiles: the editor shows the
+# previous PDF right after opening a project, clsi restores its compile
+# directory from the cache, and projects created from templates start out
+# with a PDF. It runs on this host next to clsi, so outputs are hard-linked
+# from the clsi output directory instead of being downloaded. Set it to an
+# empty string to force http downloads (e.g. when running clsi elsewhere).
+# Set CLSI_CACHE_ENABLED=false to turn it off.
+if [ "${CLSI_CACHE_ENABLED:-true}" = "true" ]; then
+  export CLSI_CACHE_SHARD="${CLSI_CACHE_SHARD:-clsi-cache-local}"
+  export CLSI_CACHE_INSTANCES="${CLSI_CACHE_INSTANCES:-[{\"url\":\"http://127.0.0.1:3044\",\"shard\":\"${CLSI_CACHE_SHARD}\"}]}"
+  export CLSI_CACHE_CURRENT_SHARDS="${CLSI_CACHE_CURRENT_SHARDS:-1}"
+  export CLSI_CACHE_DESIRED_SHARDS="${CLSI_CACHE_DESIRED_SHARDS:-1}"
+  export CLSI_CACHE_DATA_PATH="${CLSI_CACHE_DATA_PATH:-/var/lib/overleaf/data/clsi-cache}"
+  export CLSI_CACHE_LOCAL_CLSI_OUTPUT_DIR="${CLSI_CACHE_LOCAL_CLSI_OUTPUT_DIR-/var/lib/overleaf/data/output}"
+fi

--- a/server-ce/init_scripts/100_make_overleaf_data_dirs.sh
+++ b/server-ce/init_scripts/100_make_overleaf_data_dirs.sh
@@ -14,6 +14,9 @@ chown www-data:www-data /var/lib/overleaf/data/output
 mkdir -p /var/lib/overleaf/data/cache
 chown www-data:www-data /var/lib/overleaf/data/cache
 
+mkdir -p /var/lib/overleaf/data/clsi-cache
+chown www-data:www-data /var/lib/overleaf/data/clsi-cache
+
 mkdir -p /var/lib/overleaf/data/template_files
 chown www-data:www-data /var/lib/overleaf/data/template_files
 

--- a/server-ce/nginx/overleaf.conf
+++ b/server-ce/nginx/overleaf.conf
@@ -66,11 +66,26 @@ server {
   location ~ ^/project/([0-9a-f]+)/user/([0-9a-f]+)/build/([0-9a-f-]+)/output/output\.([a-z.]+)$ {
 		proxy_pass http://127.0.0.1:8080; # clsi-nginx.conf
 		proxy_http_version 1.1;
+		# clsi only keeps builds on disk for a short while; older builds live in
+		# clsi-cache, and web knows how to fall back to it (see canTryClsiCacheFallback).
+		proxy_intercept_errors on;
+		error_page 404 = @clsi_cache_fallback;
   }
   # handle output files for anonymous users
   location ~ ^/project/([0-9a-f]+)/build/([0-9a-f-]+)/output/output\.([a-z.]+)$ {
 		proxy_pass http://127.0.0.1:8080; # clsi-nginx.conf
 		proxy_http_version 1.1;
+		proxy_intercept_errors on;
+		error_page 404 = @clsi_cache_fallback;
+  }
+  location @clsi_cache_fallback {
+		proxy_pass http://127.0.0.1:4000;
+		proxy_http_version 1.1;
+		proxy_set_header Host $host;
+		proxy_set_header X-Forwarded-Host $host;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_read_timeout 10m;
+		proxy_send_timeout 10m;
   }
   # PDF range for specific users
   location ~ ^/project/([0-9a-f]+)/user/([0-9a-f]+)/content/([0-9a-f-]+/[0-9a-f]+)$ {

--- a/server-ce/runit/clsi-cache-overleaf/run
+++ b/server-ce/runit/clsi-cache-overleaf/run
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+NODE_PARAMS=""
+if [ "$DEBUG_NODE" == "true" ]; then
+    echo "running debug - clsi-cache"
+    NODE_PARAMS="--inspect=0.0.0.0:30440"
+fi
+
+source /etc/overleaf/env.sh
+export LISTEN_ADDRESS=127.0.0.1
+
+exec /sbin/setuser www-data /usr/bin/node $NODE_PARAMS /overleaf/services/clsi-cache/app.js >> /var/log/overleaf/clsi-cache.log 2>&1

--- a/server-ce/services.js
+++ b/server-ce/services.js
@@ -12,6 +12,9 @@ module.exports = [
     name: 'clsi',
   },
   {
+    name: 'clsi-cache',
+  },
+  {
     name: 'filestore',
   },
   {

--- a/services/clsi-cache/.mocharc.cjs
+++ b/services/clsi-cache/.mocharc.cjs
@@ -1,0 +1,13 @@
+let reporterOptions = {}
+if (process.env.CI) {
+  reporterOptions = {
+    reporter: require.resolve('mocha-multi-reporters'),
+    'reporter-options': ['configFile=./test/mocha-multi-reporters.cjs'],
+  }
+}
+const all = {
+  require: 'test/setup.js',
+  ...reporterOptions,
+}
+
+module.exports = all

--- a/services/clsi-cache/Dockerfile
+++ b/services/clsi-cache/Dockerfile
@@ -1,0 +1,53 @@
+# This file was auto-generated, do not edit it directly.
+# Instead run bin/update_build_scripts from
+# https://github.com/overleaf/internal/
+
+FROM node:24.14.1 AS base
+
+# Corepack setup, shared between all the images.
+ENV PATH="/overleaf/node_modules/.bin:$PATH"
+ENV COREPACK_HOME=/opt/corepack
+RUN corepack enable && corepack install -g yarn@4.14.1
+ENV COREPACK_ENABLE_NETWORK=0
+
+WORKDIR /overleaf/services/clsi-cache
+
+# Google Cloud Storage needs a writable $HOME/.config for resumable uploads
+# (see https://googleapis.dev/nodejs/storage/latest/File.html#createWriteStream)
+RUN mkdir /home/node/.config && chown node:node /home/node/.config
+
+FROM base AS app
+
+COPY package.json yarn.lock .yarnrc.yml /overleaf/
+COPY libraries/eslint-plugin/package.json /overleaf/libraries/eslint-plugin/package.json
+COPY libraries/fetch-utils/package.json /overleaf/libraries/fetch-utils/package.json
+COPY libraries/logger/package.json /overleaf/libraries/logger/package.json
+COPY libraries/metrics/package.json /overleaf/libraries/metrics/package.json
+COPY libraries/o-error/package.json /overleaf/libraries/o-error/package.json
+COPY libraries/object-persistor/package.json /overleaf/libraries/object-persistor/package.json
+COPY libraries/promise-utils/package.json /overleaf/libraries/promise-utils/package.json
+COPY libraries/settings/package.json /overleaf/libraries/settings/package.json
+COPY libraries/stream-utils/package.json /overleaf/libraries/stream-utils/package.json
+COPY libraries/validation-tools/package.json /overleaf/libraries/validation-tools/package.json
+COPY services/clsi-cache/package.json /overleaf/services/clsi-cache/package.json
+COPY .yarn/patches/ /overleaf/.yarn/patches/
+
+RUN cd /overleaf && yarn workspaces focus @overleaf/clsi-cache overleaf
+COPY libraries/eslint-plugin/ /overleaf/libraries/eslint-plugin/
+COPY libraries/fetch-utils/ /overleaf/libraries/fetch-utils/
+COPY libraries/logger/ /overleaf/libraries/logger/
+COPY libraries/metrics/ /overleaf/libraries/metrics/
+COPY libraries/o-error/ /overleaf/libraries/o-error/
+COPY libraries/object-persistor/ /overleaf/libraries/object-persistor/
+COPY libraries/promise-utils/ /overleaf/libraries/promise-utils/
+COPY libraries/settings/ /overleaf/libraries/settings/
+COPY libraries/stream-utils/ /overleaf/libraries/stream-utils/
+COPY libraries/validation-tools/ /overleaf/libraries/validation-tools/
+COPY services/clsi-cache/ /overleaf/services/clsi-cache/
+
+FROM app
+RUN mkdir -p cache \
+&&  chown node:node cache
+USER node
+
+CMD ["node", "--expose-gc", "app.js"]

--- a/services/clsi-cache/README.md
+++ b/services/clsi-cache/README.md
@@ -1,0 +1,159 @@
+# clsi-cache
+
+Stores the outputs of the most recent compiles of every project so that
+
+- the editor can show the last PDF right after opening a project, before
+  compiling (`GET /project/:id/output/cached/output.overleaf.json` in web),
+- a clsi instance that has never seen a project can restore the compile
+  directory from the last build instead of compiling from scratch,
+- projects created from a template or by cloning start out with a PDF.
+
+The clients live in `services/clsi/app/js/CLSICacheHandler.js` and
+`services/web/app/src/Features/Compile/ClsiCache*.mjs`; this service
+implements the other side of that protocol.
+
+## Protocol
+
+| Request | Purpose |
+| --- | --- |
+| `POST /enqueue` | clsi announces a finished build. The listed files are pulled from the clsi download host (or linked from disk, see below) in the background. |
+| `GET /project/:id[/user/:uid]/latest/output/:file` | Redirect to the file of the most recent build that has it, plus `X-All-Files`, `X-Last-Modified`, `X-Content-Length`, `X-Shard`, `X-Zone`. |
+| `GET /project/:id[/user/:uid]/build/:editorId-:buildId/search/output/:file` | Same for a specific build. |
+| `GET /project/:id[/user/:uid]/build/:editorId-:buildId/output/:file` | Serves the file (target of the redirects with the fs backend). |
+| `DELETE /project/:id[/user/:uid]/output` | Drop everything cached for the project ("clear cached files"). |
+| `POST /project/:id/user/:uid/import-from` | Seed a new project from another project's latest build or from a template. |
+| `POST /submission/:id/build/:editorId-:buildId/export-as-template` | Publish a template compile as the seed for projects created from it. |
+
+Only `output.pdf`, `output.log`, `output.synctex.gz`, `*.blg`,
+`output.overleaf.json`, `output.tar.gz` and `history-resync.json.gz` are
+accepted, mirroring `isAllowedFilename` in web.
+
+## Storage
+
+Files go through `@overleaf/object-persistor` (`CLSI_CACHE_BACKEND`: `fs`,
+`s3` or `gcs`) under `project/<projectId>[-<userId>]/build/<editorId>-<buildId>/`
+and `template/<templateVersionId>/<imageName>/`. Builds expire after 8 days
+(`CLSI_CACHE_BUILD_EXPIRY_MS`) and at most 2 builds per project are kept
+(`CLSI_CACHE_MAX_BUILDS_PER_PROJECT`).
+
+When clsi runs on the same host, point `CLSI_CACHE_LOCAL_CLSI_OUTPUT_DIR` at
+its output directory: outputs are then hard-linked into the cache instead of
+being downloaded, so the data exists once on disk until clsi expires its copy.
+The fallbacks are per file: outputs that are not on the local disk are fetched
+over http from the download host named in the notification, and hard-linking
+across filesystems degrades to a copy — so remote clsi instances work without
+any of this configured.
+
+## Environment variables
+
+For this service:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `LISTEN_ADDRESS` | `127.0.0.1` | Bind address (port is fixed at 3044). |
+| `CLSI_CACHE_SHARD` | `clsi-cache-<hostname>` | Shard name reported in `X-Shard`. Must equal the `shard` field of this instance's entry in `CLSI_CACHE_INSTANCES`, and must keep the `clsi-cache-` prefix (or be `cache`) — the frontend recognises cache urls by it. |
+| `ZONE` | `local` | Reported in `X-Zone`; only meaningful with a zoned multi-instance setup. |
+| `CLSI_CACHE_DATA_PATH` | `<service>/cache` | Where the fs backend stores the cache. (Not `CLSI_CACHE_PATH` — clsi already uses that name for its own disk cache.) |
+| `CLSI_CACHE_LOCAL_CLSI_OUTPUT_DIR` | unset | clsi's output directory on the same host. Set: hard-link/copy outputs from disk. Unset or empty: fetch them over http from the download host. |
+| `CLSI_CACHE_PUBLIC_URL` | request host | Base url used in redirects; only needed when web/clsi reach this service through an address it cannot infer from the request. |
+| `CLSI_CACHE_BACKEND` | `fs` | `fs`, `s3` or `gcs`. S3/GCS use the same `AWS_*`/`GCS_*` variables as filestore. |
+| `CLSI_CACHE_INGEST_CONCURRENCY` | `4` | Parallel file ingests. |
+| `CLSI_CACHE_DOWNLOAD_TIMEOUT_MS` | `30000` | Timeout per file download from clsi. |
+| `CLSI_CACHE_BUILD_EXPIRY_MS` | 8 days | Build retention (keep in sync with `clsiCacheExpiryInSeconds` in web's ClsiManager). |
+| `CLSI_CACHE_MAX_BUILDS_PER_PROJECT` | `2` | Builds kept per project, mirroring clsi's `CACHE_LIMIT`. |
+| `CLSI_CACHE_SWEEP_INTERVAL_MS` | 10 min | Expiry sweep interval; `0` disables the sweeper. |
+
+For the consumers (this is what actually switches the feature on):
+
+| Variable | Read by | Purpose |
+| --- | --- | --- |
+| `CLSI_CACHE_INSTANCES` | web + clsi | JSON list of instances, e.g. `[{"url":"http://127.0.0.1:3044","shard":"clsi-cache-local"}]`. Setting it enables every cache code path; unset disables all of them. |
+| `CLSI_CACHE_CURRENT_SHARDS` / `CLSI_CACHE_DESIRED_SHARDS` | clsi | How many of the listed shards receive writes; set both to the instance count (plus `CLSI_CACHE_RESHARD_FROM/UNTIL` when migrating between counts). |
+| `CLSI_CACHE_POPULATE_FOR_STANDARD_COMPILES` | clsi | Default `true`: also upload the PDF batch for `standard` compiles. Set `false` to restore the SaaS behaviour of skipping free compiles. |
+| `CLSI_CACHE_ENABLED` | server-ce image only | `env.sh` master switch (default `true`): derives all of the above for the single-container deployment. |
+
+## Shards: how clsi, web and the instances find each other
+
+`CLSI_CACHE_INSTANCES` is the only registry. One entry is one instance is one
+shard; `url` is where it listens, `shard` is its name. The invariant that
+everything below relies on: the `shard` of an entry equals the
+`CLSI_CACHE_SHARD` of the process behind its `url`.
+
+```
+CLSI_CACHE_INSTANCES = [ {url: A, shard: "clsi-cache-a"},      index 0
+                         {url: B, shard: "clsi-cache-b"},      index 1
+                         {url: C, shard: "clsi-cache-c"} ]     index 2
+
+                 write path (clsi)                       read path (web)
+                 ─────────────────                       ───────────────
+   compile done                                    editor opens project
+        │                                                   │
+        ▼                                                   ▼
+ idx = crc32(projectId) % N ──► entry[idx]       shuffle the list, try each url
+        │                                          until one answers 302 or 404
+        ├─ POST entry.url/enqueue                           │
+        └─ return entry.shard ─────┐                        ▼
+                                   │              response carries X-Shard
+   compile response                │                        │
+   { clsiCacheShard: "clsi-cache-b" } ◄─────────────────────┘
+        │
+        ▼
+   frontend: ?clsiserverid=clsi-cache-b on PDF urls
+   web (import-from / export-as-template):
+        instances.find(i => i.shard === "clsi-cache-b").url   ← name → url
+```
+
+Reads never depend on the name (web asks every instance); writes and the
+name→url reverse lookup do, which is why a mismatched `CLSI_CACHE_SHARD`
+breaks template/clone pre-warming while plain compiles keep working.
+
+The hash is only used at write time. A build remembers its shard name, and
+a shard that is down is skipped via a circuit breaker (`crc32(projectId-1)`,
+`-2`, ... over the remaining entries), so losing one instance only moves that
+instance's projects.
+
+## Resharding: CURRENT_SHARDS, DESIRED_SHARDS, RESHARD_FROM/UNTIL
+
+Changing N changes `crc32 % N` for most projects at once. clsi therefore
+does not switch abruptly; it moves projects over during a time window:
+
+```
+   INSTANCES list  : [ a, b, c ]        (c newly added)
+   CURRENT_SHARDS  : 2   ──► clsi hashes over [a, b]
+   DESIRED_SHARDS  : 3   ──► clsi hashes over [a, b, c]
+
+   percentile p = (last 4 bytes of the project's ObjectId) % 100   (stable per project)
+
+   share of projects
+   using DESIRED
+   100% ┤                                   ┌──────────────
+        │                               ╱
+        │                           ╱        p > (UNTIL - now) / (UNTIL - FROM)
+        │                       ╱            → this project uses DESIRED
+        │                   ╱
+     0% ┼───────────────┘
+        └───────────────┬───────────────────┬────────────► time
+                   RESHARD_FROM        RESHARD_UNTIL
+
+   before FROM : everyone on CURRENT
+   in window   : projects flip to DESIRED in order of p, linearly over the window
+   after UNTIL : everyone on DESIRED  → operator sets CURRENT=3 and drops the window
+```
+
+A project flips once and stays flipped (its percentile does not change), so
+the cache misses caused by the remap are spread over the window instead of
+hitting every project at the same moment.
+
+Single instance: `CURRENT_SHARDS=DESIRED_SHARDS=1`, no window. The values
+still have to be set — clsi reads them with `parseInt`, and an unset variable
+yields `NaN`, `slice(0, NaN)` is an empty list and no shard is ever selected.
+
+## Scaling out
+
+Any number of clsi instances can share one cache instance (the default http
+pull mode). For more than one cache instance, use a shared `s3`/`gcs` backend:
+the instances then answer lookups for each other's ingests. Running multiple
+instances on disjoint `fs` disks is NOT supported: unlike the upstream
+service, there is no coordinator that fans lookups out to the other instances,
+so web would find cached builds only by chance (clsi itself is unaffected — it
+picks the shard deterministically).

--- a/services/clsi-cache/app.js
+++ b/services/clsi-cache/app.js
@@ -1,0 +1,145 @@
+// Metrics must be initialized before importing anything else
+import '@overleaf/metrics/initialize.js'
+
+import fs from 'node:fs'
+import express from 'express'
+import bodyParser from 'body-parser'
+import Settings from '@overleaf/settings'
+import logger from '@overleaf/logger'
+import Metrics from '@overleaf/metrics'
+import { expressify } from '@overleaf/promise-utils'
+import { handleValidationError } from '@overleaf/validation-tools'
+import * as HttpController from './app/js/HttpController.js'
+import * as ExpiryManager from './app/js/ExpiryManager.js'
+import { InvalidNameError, NotFoundError } from './app/js/Errors.js'
+import {
+  EDITOR_BUILD_ID_REGEX,
+  PROJECT_ID_REGEX,
+  USER_ID_REGEX,
+} from './app/js/utils.js'
+
+logger.initialize('clsi-cache')
+Metrics.open_sockets.monitor(true)
+Metrics.memory.monitor(logger)
+Metrics.leaked_sockets.monitor(logger)
+
+const app = express()
+
+Metrics.injectMetricsRoute(app)
+app.use(Metrics.http.monitor(logger))
+
+// Downloads of large PDFs on slow connections may take a while.
+const TIMEOUT = 10 * 60 * 1000
+app.use(function (req, res, next) {
+  req.setTimeout(TIMEOUT)
+  res.setTimeout(TIMEOUT)
+  res.removeHeader('X-Powered-By')
+  next()
+})
+
+for (const [param, regex] of [
+  ['project_id', PROJECT_ID_REGEX],
+  ['submission_id', PROJECT_ID_REGEX],
+  ['user_id', USER_ID_REGEX],
+  ['editor_build_id', EDITOR_BUILD_ID_REGEX],
+]) {
+  app.param(param, function (req, res, next, value) {
+    if (regex.test(value)) {
+      next()
+    } else {
+      res.status(400).end()
+    }
+  })
+}
+
+// clsi -> clsi-cache: build notifications, then pull the outputs.
+app.post(
+  '/enqueue',
+  bodyParser.json({ limit: '20mb' }),
+  expressify(HttpController.enqueue)
+)
+
+// Lookups answer with a redirect and the X-* headers describing the build.
+app.get(
+  '/project/:project_id/user/:user_id/latest/output/:filename(.*)',
+  expressify(HttpController.getLatestOutputFile)
+)
+app.get(
+  '/project/:project_id/latest/output/:filename(.*)',
+  expressify(HttpController.getLatestOutputFile)
+)
+app.get(
+  '/project/:project_id/user/:user_id/build/:editor_build_id/search/output/:filename(.*)',
+  expressify(HttpController.getBuildOutputFile)
+)
+app.get(
+  '/project/:project_id/build/:editor_build_id/search/output/:filename(.*)',
+  expressify(HttpController.getBuildOutputFile)
+)
+
+// Where the redirects point to with the fs backend.
+app.get(
+  '/project/:project_id/user/:user_id/build/:editor_build_id/output/:filename(.*)',
+  expressify(HttpController.streamOutputFile)
+)
+app.get(
+  '/project/:project_id/build/:editor_build_id/output/:filename(.*)',
+  expressify(HttpController.streamOutputFile)
+)
+
+app.delete(
+  '/project/:project_id/user/:user_id/output',
+  expressify(HttpController.clearProject)
+)
+app.delete('/project/:project_id/output', expressify(HttpController.clearProject))
+
+app.post(
+  '/project/:project_id/user/:user_id/import-from',
+  bodyParser.json(),
+  expressify(HttpController.importFrom)
+)
+app.post(
+  '/submission/:submission_id/build/:editor_build_id/export-as-template',
+  bodyParser.json(),
+  expressify(HttpController.exportAsTemplate)
+)
+
+app.get('/status', expressify(HttpController.status))
+app.get('/health_check', expressify(HttpController.status))
+
+app.use(handleValidationError)
+app.use(function (err, req, res, next) {
+  if (err instanceof NotFoundError) {
+    res.status(404).end()
+  } else if (err instanceof InvalidNameError) {
+    res.status(400).end()
+  } else if (err.type === 'entity.too.large' || err.type === 'entity.parse.failed') {
+    res.status(err.status || 400).end()
+  } else {
+    logger.error({ err, url: req.originalUrl }, 'unhandled error')
+    res.status(500).end()
+  }
+})
+
+// The fs persistor writes temp files next to the objects, the directory must exist.
+fs.mkdirSync(Settings.path.cacheDir, { recursive: true })
+
+const { port, host } = Settings.internal.clsiCache
+const server = app.listen(port, host, function (err) {
+  if (err) {
+    logger.fatal({ err }, `cannot bind to ${host}:${port}. Exiting.`)
+    process.exit(1)
+  }
+  logger.info({ host, port, shard: Settings.shard }, 'clsi-cache starting up')
+})
+ExpiryManager.init()
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    logger.info({ signal }, 'shutting down')
+    ExpiryManager.stop()
+    server.close(() => process.exit(0))
+  })
+}
+
+export default app

--- a/services/clsi-cache/app/js/BuildStore.js
+++ b/services/clsi-cache/app/js/BuildStore.js
@@ -1,0 +1,226 @@
+import Path from 'node:path'
+import { Readable } from 'node:stream'
+import Settings from '@overleaf/settings'
+import { Errors as PersistorErrors } from '@overleaf/object-persistor'
+import persistor from './Persistor.js'
+import { NotFoundError } from './Errors.js'
+import {
+  EDITOR_BUILD_ID_REGEX,
+  getBuildTimestamp,
+  splitEditorBuildId,
+} from './utils.js'
+
+const LOCATION = Settings.path.cacheDir
+export const META_FILE = 'output.overleaf.json'
+export const isFsBackend = Settings.persistor.backend === 'fs'
+
+/**
+ * @typedef {Object} Build
+ * @property {string} editorBuildId
+ * @property {string} buildId
+ * @property {number} timestamp
+ * @property {string} prefix
+ * @property {string[]} files
+ */
+
+export function projectPrefix(projectKey) {
+  return `project/${projectKey}`
+}
+
+export function buildPrefix(projectKey, editorBuildId) {
+  return `${projectPrefix(projectKey)}/build/${editorBuildId}`
+}
+
+export function templatePrefix(templateVersionId, imageName) {
+  return `template/${templateVersionId}/${imageName}`
+}
+
+/**
+ * Absolute path of a key on disk. Only meaningful with the fs backend.
+ *
+ * @param {string} key
+ * @return {string}
+ */
+export function fsPath(key) {
+  return Path.join(LOCATION, key)
+}
+
+/**
+ * The fs backend lists absolute paths, object stores list keys.
+ *
+ * @param {string} entry
+ * @return {string}
+ */
+function toKey(entry) {
+  const base = LOCATION.replace(/\/$/, '') + '/'
+  return entry.startsWith(base) ? entry.slice(base.length) : entry
+}
+
+async function listKeys(prefix) {
+  const entries = await persistor.listDirectoryKeys(LOCATION, prefix)
+  return entries.map(toKey).filter(key => key.startsWith(prefix + '/'))
+}
+
+/**
+ * Files below a prefix, relative to it.
+ *
+ * @param {string} prefix
+ * @return {Promise<string[]>}
+ */
+export async function listFiles(prefix) {
+  const keys = await listKeys(prefix)
+  return keys.map(key => key.slice(prefix.length + 1)).sort()
+}
+
+/**
+ * All builds of a project, newest first. Stable for builds with the same
+ * timestamp, so that repeated lookups return the same "latest" build.
+ *
+ * @param {string} projectKey
+ * @return {Promise<Build[]>}
+ */
+export async function listBuilds(projectKey) {
+  const prefix = `${projectPrefix(projectKey)}/build`
+  const keys = await listKeys(prefix)
+  const builds = new Map()
+  for (const key of keys) {
+    const rest = key.slice(prefix.length + 1)
+    const idx = rest.indexOf('/')
+    if (idx === -1) continue
+    const editorBuildId = rest.slice(0, idx)
+    if (!EDITOR_BUILD_ID_REGEX.test(editorBuildId)) continue
+    let build = builds.get(editorBuildId)
+    if (!build) {
+      const { buildId } = splitEditorBuildId(editorBuildId)
+      build = {
+        editorBuildId,
+        buildId,
+        timestamp: getBuildTimestamp(buildId),
+        prefix: `${prefix}/${editorBuildId}`,
+        files: [],
+      }
+      builds.set(editorBuildId, build)
+    }
+    build.files.push(rest.slice(idx + 1))
+  }
+  const list = Array.from(builds.values())
+  for (const build of list) build.files.sort()
+  list.sort(
+    (a, b) =>
+      b.timestamp - a.timestamp || b.editorBuildId.localeCompare(a.editorBuildId)
+  )
+  return list
+}
+
+/**
+ * Most recent build that has the given file.
+ *
+ * @param {string} projectKey
+ * @param {string} filename
+ * @return {Promise<Build|undefined>}
+ */
+export async function findLatestBuild(projectKey, filename) {
+  const builds = await listBuilds(projectKey)
+  return builds.find(build => build.files.includes(filename))
+}
+
+/**
+ * A specific build, provided it has the given file.
+ *
+ * @param {string} projectKey
+ * @param {string} editorBuildId
+ * @param {string} filename
+ * @return {Promise<Build|undefined>}
+ */
+export async function findBuild(projectKey, editorBuildId, filename) {
+  const builds = await listBuilds(projectKey)
+  return builds.find(
+    build =>
+      build.editorBuildId === editorBuildId && build.files.includes(filename)
+  )
+}
+
+/**
+ * @return {Promise<string[]>}
+ */
+export async function listProjectKeys() {
+  const keys = await listKeys('project')
+  const projectKeys = new Set()
+  for (const key of keys) {
+    projectKeys.add(key.split('/')[1])
+  }
+  return Array.from(projectKeys)
+}
+
+function wrapNotFound(err, key) {
+  if (err instanceof PersistorErrors.NotFoundError) {
+    return new NotFoundError('object not found', { key })
+  }
+  return err
+}
+
+export async function getObjectSize(key) {
+  try {
+    return await persistor.getObjectSize(LOCATION, key)
+  } catch (err) {
+    throw wrapNotFound(err, key)
+  }
+}
+
+export async function getObjectStream(key, opts = {}) {
+  try {
+    return await persistor.getObjectStream(LOCATION, key, opts)
+  } catch (err) {
+    throw wrapNotFound(err, key)
+  }
+}
+
+export async function getRedirectUrl(key) {
+  return await persistor.getRedirectUrl(LOCATION, key)
+}
+
+export async function sendStream(key, stream) {
+  await persistor.sendStream(LOCATION, key, stream)
+}
+
+export async function sendFile(key, path) {
+  await persistor.sendFile(LOCATION, key, path)
+}
+
+export async function writeJSON(key, obj) {
+  await sendStream(key, Readable.from([Buffer.from(JSON.stringify(obj))]))
+}
+
+export async function readJSON(key) {
+  const stream = await getObjectStream(key)
+  const chunks = []
+  for await (const chunk of stream) chunks.push(chunk)
+  return JSON.parse(Buffer.concat(chunks).toString())
+}
+
+export async function deleteObject(key) {
+  await persistor.deleteObject(LOCATION, key)
+}
+
+export async function deleteDirectory(prefix) {
+  await persistor.deleteDirectory(LOCATION, prefix)
+}
+
+/**
+ * Copy every file below a prefix to another prefix.
+ *
+ * @param {string} srcPrefix
+ * @param {string} dstPrefix
+ * @return {Promise<string[]>} copied files, relative to the prefixes
+ */
+export async function copyPrefix(srcPrefix, dstPrefix) {
+  const files = await listFiles(srcPrefix)
+  for (const file of files) {
+    await persistor.copyObject(
+      LOCATION,
+      `${srcPrefix}/${file}`,
+      `${dstPrefix}/${file}`
+    )
+  }
+  return files
+}

--- a/services/clsi-cache/app/js/Errors.js
+++ b/services/clsi-cache/app/js/Errors.js
@@ -1,0 +1,5 @@
+import OError from '@overleaf/o-error'
+
+export class NotFoundError extends OError {}
+export class InvalidNameError extends OError {}
+export class InvalidTarballError extends OError {}

--- a/services/clsi-cache/app/js/ExpiryManager.js
+++ b/services/clsi-cache/app/js/ExpiryManager.js
@@ -1,0 +1,61 @@
+import Settings from '@overleaf/settings'
+import logger from '@overleaf/logger'
+import Metrics from '@overleaf/metrics'
+import * as BuildStore from './BuildStore.js'
+import { isInflight } from './IngestManager.js'
+
+let timer
+let sweeping = false
+
+export function init() {
+  const { sweepIntervalMs } = Settings.expiry
+  if (!sweepIntervalMs) return
+  timer = setInterval(() => {
+    sweep().catch(err => logger.warn({ err }, 'clsi-cache sweep failed'))
+  }, sweepIntervalMs)
+  timer.unref()
+}
+
+export function stop() {
+  clearInterval(timer)
+}
+
+/**
+ * Drop builds that are older than the expiry or beyond the per-project limit.
+ * Templates are kept: they are tied to a template version and only replaced
+ * when the template is published again.
+ *
+ * @return {Promise<{projects: number, deleted: number}>}
+ */
+export async function sweep() {
+  if (sweeping) return { projects: 0, deleted: 0 }
+  sweeping = true
+  const { buildAgeMs, maxBuildsPerProject } = Settings.expiry
+  const now = Date.now()
+  let deleted = 0
+  try {
+    const projectKeys = await BuildStore.listProjectKeys()
+    for (const projectKey of projectKeys) {
+      const builds = await BuildStore.listBuilds(projectKey)
+      for (const [index, build] of builds.entries()) {
+        if (isInflight(build.prefix)) continue
+        const expired = now - build.timestamp > buildAgeMs
+        if (expired || index >= maxBuildsPerProject) {
+          await BuildStore.deleteDirectory(build.prefix)
+          deleted++
+        }
+      }
+      if (builds.length > 0 && deleted > 0) {
+        const remaining = await BuildStore.listBuilds(projectKey)
+        if (remaining.length === 0) {
+          await BuildStore.deleteDirectory(BuildStore.projectPrefix(projectKey))
+        }
+      }
+    }
+    Metrics.count('clsi_cache_expired_builds', deleted)
+    logger.debug({ projects: projectKeys.length, deleted }, 'clsi-cache sweep')
+    return { projects: projectKeys.length, deleted }
+  } finally {
+    sweeping = false
+  }
+}

--- a/services/clsi-cache/app/js/HttpController.js
+++ b/services/clsi-cache/app/js/HttpController.js
@@ -1,0 +1,369 @@
+import crypto from 'node:crypto'
+import Path from 'node:path'
+import { pipeline } from 'node:stream/promises'
+import { setTimeout as sleep } from 'node:timers/promises'
+import Settings from '@overleaf/settings'
+import logger from '@overleaf/logger'
+import Metrics from '@overleaf/metrics'
+import { MeteredStream } from '@overleaf/stream-utils'
+import { z, zz, parseReq } from '@overleaf/validation-tools'
+import * as BuildStore from './BuildStore.js'
+import * as IngestManager from './IngestManager.js'
+import { NotFoundError } from './Errors.js'
+import {
+  BUILD_ID_REGEX,
+  EDITOR_BUILD_ID_REGEX,
+  PROJECT_ID_REGEX,
+  generateBuildId,
+  getIngressLabel,
+  getProjectKey,
+  validateFilename,
+} from './utils.js'
+
+const CONTENT_TYPES = {
+  '.pdf': 'application/pdf',
+  '.log': 'text/plain; charset=utf-8',
+  '.blg': 'text/plain; charset=utf-8',
+  '.json': 'application/json',
+  '.gz': 'application/gzip',
+}
+
+// ---- schemas ---------------------------------------------------------------
+
+const projectParamsSchema = z.object({
+  project_id: z.string().regex(PROJECT_ID_REGEX),
+  user_id: zz.objectId().optional(),
+})
+
+const fileParamsSchema = projectParamsSchema.extend({
+  filename: zz.filepath(),
+})
+
+const buildFileParamsSchema = fileParamsSchema.extend({
+  editor_build_id: z.string().regex(EDITOR_BUILD_ID_REGEX),
+})
+
+const enqueueSchema = z.object({
+  body: z.object({
+    projectId: z.string().regex(PROJECT_ID_REGEX),
+    userId: zz.objectId().nullish(),
+    buildId: z.string().regex(BUILD_ID_REGEX),
+    editorId: z.string().regex(/^[a-f0-9-]{36}$/),
+    files: z.array(
+      z.object({
+        path: zz.filepath(),
+        size: z.number().int().nonnegative().optional(),
+        contentId: z.string().optional(),
+        ranges: z.array(z.any()).optional(),
+      })
+    ),
+    downloadHost: z.string().url(),
+    clsiServerId: z.string(),
+    compileGroup: z.string().optional(),
+    stats: z.record(z.string(), z.any()).optional(),
+    timings: z.record(z.string(), z.any()).optional(),
+    options: z.record(z.string(), z.any()).optional(),
+  }),
+})
+
+const importFromSchema = z.object({
+  params: z.object({
+    project_id: zz.objectId(),
+    user_id: zz.objectId(),
+  }),
+  body: z.object({
+    sourceProjectId: zz.objectId().optional(),
+    lastUpdated: z.union([z.string(), z.number()]).nullish(),
+    templateVersionId: z.string().min(1).optional(),
+    imageName: z.string().min(1).optional(),
+  }),
+})
+
+const exportAsTemplateSchema = z.object({
+  params: z.object({
+    submission_id: z.string().regex(PROJECT_ID_REGEX),
+    editor_build_id: z.string().regex(EDITOR_BUILD_ID_REGEX),
+  }),
+  body: z.object({
+    templateVersionId: z.string().min(1),
+    imageName: z.string().min(1),
+  }),
+})
+
+// ---- helpers ---------------------------------------------------------------
+
+function selfUrl(req) {
+  return Settings.publicUrl || `${req.protocol}://${req.get('host')}`
+}
+
+/**
+ * Headers web reads in getRedirectWithFallback (ClsiCacheHandler.mjs).
+ */
+function setLookupHeaders(res, build, size) {
+  const allFiles = JSON.stringify(build.files)
+  res.set(
+    'X-All-Files',
+    // Header values must be ASCII, .blg files may carry custom names.
+    /^[\x20-\x7e]*$/.test(allFiles)
+      ? allFiles
+      : Buffer.from(allFiles).toString('base64url')
+  )
+  res.set('X-Last-Modified', new Date(build.timestamp).toISOString())
+  res.set('X-Content-Length', String(size))
+  res.set('X-Shard', Settings.shard)
+  res.set('X-Zone', Settings.zone)
+}
+
+/**
+ * Answer a lookup with a redirect to the file. Object stores hand out signed
+ * urls; with the fs backend the file is served by this instance. web parses
+ * editorId/buildId back out of the "/build/<editorId>-<buildId>/" path segment.
+ */
+async function redirectToBuildFile(req, res, projectId, userId, build, filename) {
+  const key = `${build.prefix}/${filename}`
+  const size = await BuildStore.getObjectSize(key)
+  const location =
+    (await BuildStore.getRedirectUrl(key)) ||
+    `${selfUrl(req)}/project/${projectId}${
+      userId ? `/user/${userId}` : ''
+    }/build/${build.editorBuildId}/output/${filename}`
+  setLookupHeaders(res, build, size)
+  res.redirect(302, location)
+}
+
+/**
+ * @param {string|undefined} header
+ * @param {number} size
+ * @return {{start: number, end: number}|null}
+ */
+function parseRange(header, size) {
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header || '')
+  if (!match || (match[1] === '' && match[2] === '')) return null
+  let start, end
+  if (match[1] === '') {
+    // suffix range: the last N bytes
+    start = Math.max(0, size - parseInt(match[2], 10))
+    end = size - 1
+  } else {
+    start = parseInt(match[1], 10)
+    end = match[2] === '' ? size - 1 : Math.min(parseInt(match[2], 10), size - 1)
+  }
+  if (start > end || start >= size) return null
+  return { start, end }
+}
+
+// ---- handlers --------------------------------------------------------------
+
+export async function enqueue(req, res) {
+  const { body } = parseReq(req, enqueueSchema)
+  IngestManager.enqueue(body)
+  res.sendStatus(204)
+}
+
+export async function getLatestOutputFile(req, res) {
+  const {
+    params: { project_id: projectId, user_id: userId, filename },
+  } = parseReq(req, z.object({ params: fileParamsSchema }))
+  validateFilename(filename)
+  const projectKey = getProjectKey(projectId, userId)
+  const build = await BuildStore.findLatestBuild(projectKey, filename)
+  if (!build) throw new NotFoundError('nothing cached', { projectKey })
+  await redirectToBuildFile(req, res, projectId, userId, build, filename)
+}
+
+export async function getBuildOutputFile(req, res) {
+  const {
+    params: {
+      project_id: projectId,
+      user_id: userId,
+      editor_build_id: editorBuildId,
+      filename,
+    },
+  } = parseReq(req, z.object({ params: buildFileParamsSchema }))
+  validateFilename(filename)
+  const projectKey = getProjectKey(projectId, userId)
+  const build = await BuildStore.findBuild(projectKey, editorBuildId, filename)
+  if (!build) {
+    throw new NotFoundError('build not cached', { projectKey, editorBuildId })
+  }
+  await redirectToBuildFile(req, res, projectId, userId, build, filename)
+}
+
+/**
+ * Serve a file. This is where the redirects from the lookups point to
+ * when the persistor cannot hand out urls itself.
+ */
+export async function streamOutputFile(req, res) {
+  const {
+    params: {
+      project_id: projectId,
+      user_id: userId,
+      editor_build_id: editorBuildId,
+      filename,
+    },
+  } = parseReq(req, z.object({ params: buildFileParamsSchema }))
+  validateFilename(filename)
+  const key = `${BuildStore.buildPrefix(
+    getProjectKey(projectId, userId),
+    editorBuildId
+  )}/${filename}`
+
+  const size = await BuildStore.getObjectSize(key)
+  const range = parseRange(req.headers.range, size)
+  const stream = await BuildStore.getObjectStream(key, range || {})
+
+  res.set('Accept-Ranges', 'bytes')
+  res.set(
+    'Content-Type',
+    CONTENT_TYPES[Path.extname(filename)] || 'application/octet-stream'
+  )
+  if (range) {
+    res.status(206)
+    res.set('Content-Range', `bytes ${range.start}-${range.end}/${size}`)
+    res.set('Content-Length', String(range.end - range.start + 1))
+  } else {
+    res.set('Content-Length', String(size))
+  }
+
+  try {
+    await pipeline(
+      stream,
+      new MeteredStream(Metrics, 'clsi_cache_egress', {
+        path: getIngressLabel(filename),
+      }),
+      res
+    )
+  } catch (err) {
+    if (req.destroyed || res.headersSent) {
+      // The client went away mid-transfer, nothing left to report.
+      logger.debug({ err, key }, 'output file transfer interrupted')
+      return
+    }
+    throw err
+  }
+}
+
+export async function clearProject(req, res) {
+  const {
+    params: { project_id: projectId, user_id: userId },
+  } = parseReq(req, z.object({ params: projectParamsSchema }))
+  const projectKey = getProjectKey(projectId, userId)
+  await BuildStore.deleteDirectory(BuildStore.projectPrefix(projectKey))
+  res.sendStatus(204)
+}
+
+/**
+ * Seed the cache of a new project from another project or a template.
+ * See prepareCacheSource in services/web/app/src/Features/Compile/ClsiCacheHandler.mjs
+ */
+export async function importFrom(req, res) {
+  const {
+    params: { project_id: projectId, user_id: userId },
+    body: { sourceProjectId, lastUpdated, templateVersionId, imageName },
+  } = parseReq(req, importFromSchema)
+
+  let sourcePrefix
+  if (sourceProjectId) {
+    // Both projects belong to the same user, so look at their per-user compile
+    // first; fall back to a shared compile of the source project.
+    const build =
+      (await BuildStore.findLatestBuild(
+        getProjectKey(sourceProjectId, userId),
+        'output.tar.gz'
+      )) ||
+      (await BuildStore.findLatestBuild(sourceProjectId, 'output.tar.gz'))
+    if (!build) {
+      throw new NotFoundError('source project not cached', { sourceProjectId })
+    }
+    // Never seed a new project from an outdated build of the source project:
+    // the copy would pass the up-to-date check of the new project.
+    if (lastUpdated != null && build.timestamp < new Date(lastUpdated).getTime()) {
+      throw new NotFoundError('source build is stale', {
+        sourceProjectId,
+        buildId: build.buildId,
+      })
+    }
+    sourcePrefix = build.prefix
+  } else if (templateVersionId && imageName) {
+    sourcePrefix = BuildStore.templatePrefix(
+      templateVersionId,
+      Path.basename(imageName)
+    )
+    const files = await BuildStore.listFiles(sourcePrefix)
+    if (!files.includes('output.tar.gz')) {
+      throw new NotFoundError('template not cached', {
+        templateVersionId,
+        imageName,
+      })
+    }
+  } else {
+    return res.status(400).json({ error: 'missing source' })
+  }
+
+  // The copy is a fresh build of the new project: stamped now, so that it is
+  // newer than the project record created a moment ago.
+  const editorBuildId = `${crypto.randomUUID()}-${generateBuildId()}`
+  const dstPrefix = BuildStore.buildPrefix(
+    getProjectKey(projectId, userId),
+    editorBuildId
+  )
+  const files = await BuildStore.copyPrefix(sourcePrefix, dstPrefix)
+  Metrics.inc('clsi_cache_import', 1, {
+    source: sourceProjectId ? 'project' : 'template',
+  })
+  logger.debug(
+    { projectId, userId, sourcePrefix, editorBuildId, files },
+    'seeded clsi-cache'
+  )
+  res.sendStatus(204)
+}
+
+/**
+ * Publish the outputs of a submission (template compile) as the cache
+ * source for projects created from the template.
+ * See exportSubmissionAsTemplate in services/web/app/src/Features/Compile/ClsiCacheHandler.mjs
+ */
+export async function exportAsTemplate(req, res) {
+  const {
+    params: { submission_id: submissionId, editor_build_id: editorBuildId },
+    body: { templateVersionId, imageName },
+  } = parseReq(req, exportAsTemplateSchema)
+
+  // Submissions compile without a user id.
+  const prefix = BuildStore.buildPrefix(submissionId, editorBuildId)
+  // The outputs arrive from clsi asynchronously; web allows us to poll for up to 15s.
+  const deadline = Date.now() + Settings.ingest.exportWaitMs
+  let files
+  for (;;) {
+    await IngestManager.waitForBuild(prefix, deadline - Date.now())
+    files = await BuildStore.listFiles(prefix)
+    if (files.includes('output.tar.gz') && files.includes(BuildStore.META_FILE)) {
+      break
+    }
+    if (Date.now() > deadline) {
+      throw new NotFoundError('submission build not cached', {
+        submissionId,
+        editorBuildId,
+        files,
+      })
+    }
+    await sleep(500)
+  }
+
+  const dstPrefix = BuildStore.templatePrefix(
+    templateVersionId,
+    Path.basename(imageName)
+  )
+  await BuildStore.deleteDirectory(dstPrefix)
+  await BuildStore.copyPrefix(prefix, dstPrefix)
+  Metrics.inc('clsi_cache_export_template')
+  logger.debug(
+    { submissionId, editorBuildId, templateVersionId, imageName, files },
+    'exported submission build as template'
+  )
+  res.sendStatus(204)
+}
+
+export async function status(req, res) {
+  res.send('clsi-cache is up')
+}

--- a/services/clsi-cache/app/js/IngestManager.js
+++ b/services/clsi-cache/app/js/IngestManager.js
@@ -1,0 +1,287 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import Path from 'node:path'
+import { pipeline } from 'node:stream/promises'
+import { createGunzip } from 'node:zlib'
+import { setTimeout as sleep } from 'node:timers/promises'
+import pLimit from 'p-limit'
+import tarFs from 'tar-fs'
+import Settings from '@overleaf/settings'
+import logger from '@overleaf/logger'
+import Metrics from '@overleaf/metrics'
+import { fetchStream } from '@overleaf/fetch-utils'
+import { MeteredStream } from '@overleaf/stream-utils'
+import * as BuildStore from './BuildStore.js'
+import { InvalidTarballError } from './Errors.js'
+import { getIngressLabel, getProjectKey, validateFilename } from './utils.js'
+
+// Same layout as OutputCacheManager.CACHE_SUBDIR in clsi.
+const CLSI_OUTPUT_SUBDIR = 'generated-files'
+// Errors from fs.link that mean "fall back to copying", everything else is unexpected.
+const LINK_FALLBACK_ERRORS = ['EXDEV', 'EPERM', 'EMLINK', 'ENOTSUP', 'EACCES']
+
+const limit = pLimit(Settings.ingest.concurrency)
+
+/**
+ * Number of enqueue jobs still running per build prefix. export-as-template
+ * waits for this to drain before copying a build.
+ *
+ * @type {Map<string, number>}
+ */
+const inflight = new Map()
+
+function track(prefix, delta) {
+  const n = (inflight.get(prefix) || 0) + delta
+  if (n <= 0) {
+    inflight.delete(prefix)
+  } else {
+    inflight.set(prefix, n)
+  }
+}
+
+/**
+ * @param {string} prefix
+ * @return {boolean}
+ */
+export function isInflight(prefix) {
+  return inflight.has(prefix)
+}
+
+/**
+ * @param {string} prefix
+ * @param {number} timeoutMs
+ * @return {Promise<boolean>} false when the timeout expired first
+ */
+export async function waitForBuild(prefix, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  while (inflight.has(prefix)) {
+    if (Date.now() > deadline) return false
+    await sleep(250)
+  }
+  return true
+}
+
+/**
+ * @typedef {Object} EnqueueJob
+ * @property {string} projectId
+ * @property {string} [userId]
+ * @property {string} buildId
+ * @property {string} editorId
+ * @property {Array<{path: string, size?: number, contentId?: string, ranges?: any[]}>} files
+ * @property {string} downloadHost
+ * @property {string} clsiServerId
+ * @property {string} compileGroup
+ * @property {Object} stats
+ * @property {Object} timings
+ * @property {Object} options
+ */
+
+/**
+ * Accept a build notification from clsi. The files are copied in the
+ * background; clsi only waits for the request to be acknowledged.
+ *
+ * @param {EnqueueJob} job
+ * @return {string} build prefix
+ */
+export function enqueue(job) {
+  const projectKey = getProjectKey(job.projectId, job.userId)
+  const prefix = BuildStore.buildPrefix(
+    projectKey,
+    `${job.editorId}-${job.buildId}`
+  )
+  Metrics.count('clsi_cache_enqueue_files', job.files.length)
+  track(prefix, 1)
+  limit(() => processJob(job, projectKey, prefix))
+    .catch(err => {
+      logger.warn(
+        {
+          err,
+          projectId: job.projectId,
+          userId: job.userId,
+          buildId: job.buildId,
+        },
+        'ingest of clsi build failed'
+      )
+    })
+    .finally(() => track(prefix, -1))
+  return prefix
+}
+
+async function processJob(job, projectKey, prefix) {
+  const timer = new Metrics.Timer('clsi_cache_ingest_job')
+  let pdfEntry
+  for (const file of job.files) {
+    try {
+      validateFilename(file.path)
+    } catch (err) {
+      logger.warn({ err, path: file.path }, 'refusing to ingest output file')
+      continue
+    }
+    try {
+      await ingestFile(job, projectKey, prefix, file)
+      if (file.path === 'output.pdf') pdfEntry = file
+    } catch (err) {
+      Metrics.inc('clsi_cache_ingest_failed', 1, {
+        path: getIngressLabel(file.path),
+      })
+      logger.warn(
+        {
+          err,
+          projectId: job.projectId,
+          userId: job.userId,
+          buildId: job.buildId,
+          path: file.path,
+        },
+        'failed to ingest output file'
+      )
+    }
+  }
+  // The meta file is what web looks up first. Only write it once the PDF
+  // is in place, so that a build is never listed without its PDF.
+  if (pdfEntry) {
+    await writeMeta(prefix, job, pdfEntry)
+  }
+  timer.done()
+}
+
+async function ingestFile(job, projectKey, prefix, file) {
+  const key = `${prefix}/${file.path}`
+  const label = getIngressLabel(file.path)
+
+  if (Settings.path.localClsiOutputDir) {
+    const src = Path.join(
+      Settings.path.localClsiOutputDir,
+      projectKey,
+      CLSI_OUTPUT_SUBDIR,
+      job.buildId,
+      file.path
+    )
+    if (await importFromLocalDisk(src, key, label)) {
+      await validateTarballIfNeeded(file.path, key)
+      return
+    }
+    // Not on this host: the build ran on another clsi or expired already.
+  }
+
+  await downloadFromClsi(job, file, key, label)
+  await validateTarballIfNeeded(file.path, key)
+}
+
+/**
+ * Hard-link the output file into the cache when both live on the same
+ * filesystem, copy it otherwise. Either way clsi can expire its copy
+ * independently of ours.
+ *
+ * @return {Promise<boolean>} false when the file does not exist on disk
+ */
+async function importFromLocalDisk(src, key, label) {
+  let stat
+  try {
+    stat = await fs.promises.stat(src)
+  } catch (err) {
+    if (err.code === 'ENOENT') return false
+    throw err
+  }
+
+  if (BuildStore.isFsBackend) {
+    const dst = BuildStore.fsPath(key)
+    await fs.promises.mkdir(Path.dirname(dst), { recursive: true })
+    try {
+      await fs.promises.link(src, dst)
+      Metrics.count('clsi_cache_ingress', stat.size, 1, {
+        path: label,
+        method: 'link',
+      })
+      return true
+    } catch (err) {
+      // Re-delivery of a build we already have.
+      if (err.code === 'EEXIST') return true
+      if (!LINK_FALLBACK_ERRORS.includes(err.code)) throw err
+    }
+  }
+
+  await BuildStore.sendFile(key, src)
+  Metrics.count('clsi_cache_ingress', stat.size, 1, {
+    path: label,
+    method: 'copy',
+  })
+  return true
+}
+
+async function downloadFromClsi(job, file, key, label) {
+  const url = new URL(
+    `/project/${job.projectId}${
+      job.userId ? `/user/${job.userId}` : ''
+    }/build/${job.buildId}/output/${file.path}`,
+    job.downloadHost
+  )
+  const stream = await fetchStream(url, {
+    signal: AbortSignal.timeout(Settings.ingest.downloadTimeoutMs),
+  })
+  const metered = new MeteredStream(Metrics, 'clsi_cache_ingress', {
+    path: label,
+    method: 'download',
+  })
+  stream.on('error', err => metered.destroy(err))
+  await BuildStore.sendStream(key, stream.pipe(metered))
+}
+
+/**
+ * clsi refuses tar-balls with too many entries or special files when
+ * restoring a compile dir; drop them here so they are never served.
+ */
+async function validateTarballIfNeeded(path, key) {
+  if (path !== 'output.tar.gz') return
+  let n = 0
+  let reason
+  const tmpDir = await fs.promises.mkdtemp(
+    Path.join(os.tmpdir(), 'clsi-cache-tar-')
+  )
+  try {
+    const stream = await BuildStore.getObjectStream(key)
+    await pipeline(
+      stream,
+      createGunzip(),
+      tarFs.extract(tmpDir, {
+        // Only inspect the headers, never write anything to disk.
+        ignore(_, header) {
+          if (reason) return true
+          n++
+          if (n > Settings.ingest.maxTarEntries) {
+            reason = 'too many entries'
+          } else if (header.type !== 'file' && header.type !== 'directory') {
+            reason = `unexpected entry type ${header.type}`
+          }
+          return true
+        },
+      })
+    )
+  } finally {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true })
+  }
+  if (reason) {
+    await BuildStore.deleteObject(key)
+    throw new InvalidTarballError(reason, { key, entries: n })
+  }
+}
+
+/**
+ * Metadata web needs to build a compile response from the cache, see
+ * tryGetLatestCompileResult in services/web/app/src/Features/Compile/ClsiCacheManager.mjs
+ */
+async function writeMeta(prefix, job, pdfEntry) {
+  let { size } = pdfEntry
+  if (size == null) {
+    size = await BuildStore.getObjectSize(`${prefix}/output.pdf`)
+  }
+  await BuildStore.writeJSON(`${prefix}/${BuildStore.META_FILE}`, {
+    ranges: pdfEntry.ranges,
+    contentId: pdfEntry.contentId,
+    size,
+    clsiServerId: job.clsiServerId,
+    compileGroup: job.compileGroup,
+    options: job.options,
+    stats: job.stats,
+    timings: job.timings,
+  })
+}

--- a/services/clsi-cache/app/js/Persistor.js
+++ b/services/clsi-cache/app/js/Persistor.js
@@ -1,0 +1,7 @@
+import Settings from '@overleaf/settings'
+import ObjectPersistor from '@overleaf/object-persistor'
+
+const persistorSettings = { ...Settings.persistor, paths: Settings.path }
+const persistor = ObjectPersistor(persistorSettings)
+
+export default persistor

--- a/services/clsi-cache/app/js/utils.js
+++ b/services/clsi-cache/app/js/utils.js
@@ -1,0 +1,100 @@
+import crypto from 'node:crypto'
+import { InvalidNameError } from './Errors.js'
+
+const FIXED_FILENAMES = [
+  'output.blg',
+  'output.log',
+  'output.pdf',
+  'output.synctex.gz',
+  'output.overleaf.json',
+  'output.tar.gz',
+  // Only read/written by clsi, web blocks it from users.
+  'history-resync.json.gz',
+]
+
+/**
+ * Keep in sync with isAllowedFilename in services/web/app/src/Features/Compile/ClsiCacheHandler.mjs
+ *
+ * @param {string} filename
+ * @return {boolean}
+ */
+export function isAllowedFilename(filename) {
+  return FIXED_FILENAMES.includes(filename) || filename.endsWith('.blg')
+}
+
+/**
+ * Keep in sync with validateFilename in services/web/app/src/Features/Compile/ClsiCacheHandler.mjs
+ *
+ * @param {string} filename
+ */
+export function validateFilename(filename) {
+  if (filename.split('/').includes('..')) {
+    throw new InvalidNameError('path traversal', { filename })
+  }
+  if (!isAllowedFilename(filename)) {
+    throw new InvalidNameError('bad filename', { filename })
+  }
+}
+
+/**
+ * Keep in sync with getEgressLabel in services/web/app/src/Features/Compile/ClsiCacheHandler.mjs
+ *
+ * @param {string} fsPath
+ * @return {string}
+ */
+export function getIngressLabel(fsPath) {
+  if (fsPath.endsWith('.blg')) {
+    // .blg files may have custom names and can be in nested folders.
+    return 'output.blg'
+  }
+  return fsPath
+}
+
+// editorId is a uuid, buildId is HEXDATE-HEXRANDOM (OutputCacheManager.generateBuildId in clsi).
+export const EDITOR_BUILD_ID_REGEX = /^[a-f0-9-]{36}-[0-9a-f]+-[0-9a-f]+$/
+export const BUILD_ID_REGEX = /^[0-9a-f]+-[0-9a-f]+$/
+// Mongo ObjectIds for projects, free-form ids for submissions (external compiles).
+export const PROJECT_ID_REGEX = /^[a-zA-Z0-9_-]+$/
+export const USER_ID_REGEX = /^[0-9a-f]{24}$/
+
+/**
+ * @param {string} editorBuildId
+ * @return {{editorId: string, buildId: string}}
+ */
+export function splitEditorBuildId(editorBuildId) {
+  return {
+    editorId: editorBuildId.slice(0, 36),
+    buildId: editorBuildId.slice(37),
+  }
+}
+
+/**
+ * The build timestamp doubles as compile time: clsi generates it from Date.now()
+ * when the compile starts, which is what "last compiled" has to be compared
+ * against the project's lastUpdated.
+ *
+ * @param {string} buildId
+ * @return {number}
+ */
+export function getBuildTimestamp(buildId) {
+  return parseInt(buildId.split('-')[0], 16)
+}
+
+/**
+ * @param {number} timestamp
+ * @return {string}
+ */
+export function generateBuildId(timestamp = Date.now()) {
+  return `${timestamp.toString(16)}-${crypto.randomBytes(8).toString('hex')}`
+}
+
+/**
+ * Same layout as clsi uses on disk: per-user compiles live in "projectId-userId".
+ *
+ * @param {string} projectId
+ * @param {string} [userId]
+ * @return {string}
+ */
+export function getProjectKey(projectId, userId) {
+  return userId ? `${projectId}-${userId}` : projectId
+}

--- a/services/clsi-cache/buildscript.txt
+++ b/services/clsi-cache/buildscript.txt
@@ -1,0 +1,10 @@
+clsi-cache
+--data-dirs=cache
+--dependencies=
+--env-add=
+--env-pass-through=
+--esmock-loader=False
+--node-version=24.14.1
+--package-name=@overleaf/clsi-cache
+--pipeline-owner=32
+--public-repo=True

--- a/services/clsi-cache/config/settings.defaults.cjs
+++ b/services/clsi-cache/config/settings.defaults.cjs
@@ -1,0 +1,84 @@
+const Path = require('node:path')
+const os = require('node:os')
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+module.exports = {
+  internal: {
+    clsiCache: {
+      port: 3044,
+      host: process.env.LISTEN_ADDRESS || '127.0.0.1',
+    },
+  },
+
+  // Identity reported to web/clsi via the X-Shard/X-Zone headers. web resolves
+  // the shard name back to an instance URL through CLSI_CACHE_INSTANCES, and
+  // the frontend recognises cache urls by the "clsi-cache-" prefix
+  // (see usesCache in frontend/js/features/pdf-preview/util/pdf-caching-transport.ts).
+  shard: process.env.CLSI_CACHE_SHARD || `clsi-cache-${os.hostname()}`,
+  zone: process.env.ZONE || 'local',
+
+  // Base url used in the redirects sent to web/clsi. Defaults to the host the
+  // request came in on, which is correct as long as they share the network.
+  publicUrl: process.env.CLSI_CACHE_PUBLIC_URL,
+
+  path: {
+    cacheDir:
+      process.env.CLSI_CACHE_DATA_PATH || Path.resolve(__dirname, '../cache'),
+    // Compile output directory of a clsi running on the same host. When set,
+    // outputs are hard-linked (or copied) from disk instead of being fetched
+    // over http from the clsi download host.
+    localClsiOutputDir: process.env.CLSI_CACHE_LOCAL_CLSI_OUTPUT_DIR,
+  },
+
+  persistor: {
+    // s3 - Amazon S3, gcs - Google Cloud Storage, fs - local filesystem
+    backend: process.env.CLSI_CACHE_BACKEND || 'fs',
+    useSubdirectories: true,
+
+    gcs: {
+      endpoint: process.env.GCS_API_ENDPOINT
+        ? {
+            apiEndpoint: process.env.GCS_API_ENDPOINT,
+            projectId: process.env.GCS_PROJECT_ID,
+          }
+        : undefined,
+      unlockBeforeDelete: process.env.GCS_UNLOCK_BEFORE_DELETE === 'true',
+      deletedBucketSuffix: process.env.GCS_DELETED_BUCKET_SUFFIX,
+      deleteConcurrency: parseInt(process.env.GCS_DELETE_CONCURRENCY) || 50,
+      signedUrlExpiryInMs: parseInt(process.env.LINK_EXPIRY_TIMEOUT || 60000),
+    },
+
+    s3: {
+      key: process.env.AWS_ACCESS_KEY_ID,
+      secret: process.env.AWS_SECRET_ACCESS_KEY,
+      endpoint: process.env.AWS_S3_ENDPOINT,
+      pathStyle: process.env.AWS_S3_PATH_STYLE,
+      partSize: process.env.AWS_S3_PARTSIZE || 100 * 1024 * 1024,
+      bucketCreds: process.env.S3_BUCKET_CREDENTIALS
+        ? JSON.parse(process.env.S3_BUCKET_CREDENTIALS)
+        : undefined,
+    },
+  },
+
+  ingest: {
+    concurrency: parseInt(process.env.CLSI_CACHE_INGEST_CONCURRENCY, 10) || 4,
+    downloadTimeoutMs:
+      parseInt(process.env.CLSI_CACHE_DOWNLOAD_TIMEOUT_MS, 10) || 30_000,
+    // Keep in sync with MAX_ENTRIES_IN_OUTPUT_TAR in services/clsi/app/js/CLSICacheHandler.js
+    maxTarEntries: 100,
+    // web waits 30s for export-as-template, of which we may spend 15s waiting
+    // for the outputs to arrive from clsi (see ClsiCacheHandler.exportSubmissionAsTemplate).
+    exportWaitMs: 15_000,
+  },
+
+  expiry: {
+    // Keep in sync with clsiCacheExpiryInSeconds in services/web/app/src/Features/Compile/ClsiManager.mjs
+    buildAgeMs: parseInt(process.env.CLSI_CACHE_BUILD_EXPIRY_MS, 10) || 8 * DAY_MS,
+    // clsi keeps CACHE_LIMIT=2 builds per project on its own disk, mirror that.
+    maxBuildsPerProject:
+      parseInt(process.env.CLSI_CACHE_MAX_BUILDS_PER_PROJECT, 10) || 2,
+    sweepIntervalMs:
+      parseInt(process.env.CLSI_CACHE_SWEEP_INTERVAL_MS, 10) || 10 * 60 * 1000,
+  },
+}

--- a/services/clsi-cache/package.json
+++ b/services/clsi-cache/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@overleaf/clsi-cache",
+  "description": "Cache for compile outputs, shared between the clsi instances and web",
+  "private": true,
+  "main": "app.js",
+  "type": "module",
+  "scripts": {
+    "start": "node app.js",
+    "test:acceptance": "yarn run test:acceptance:_run -- --grep=$MOCHA_GREP",
+    "test:unit": "yarn run test:unit:_run -- --grep=$MOCHA_GREP",
+    "nodemon": "node --watch app.js",
+    "test:acceptance:_run": "mocha --recursive --timeout 15000 --exit --retries=$RETRIES $@ test/acceptance/js",
+    "test:unit:_run": "mocha --recursive --exit $@ test/unit/js",
+    "lint": "eslint --cache --cache-location ../../.cache/eslint/ --max-warnings 0 --format unix .",
+    "lint:fix": "eslint --cache --cache-location ../../.cache/eslint/ --fix .",
+    "types:check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@overleaf/fetch-utils": "workspace:*",
+    "@overleaf/logger": "workspace:*",
+    "@overleaf/metrics": "workspace:*",
+    "@overleaf/o-error": "workspace:*",
+    "@overleaf/object-persistor": "workspace:*",
+    "@overleaf/promise-utils": "workspace:*",
+    "@overleaf/settings": "workspace:*",
+    "@overleaf/stream-utils": "workspace:*",
+    "@overleaf/validation-tools": "workspace:*",
+    "body-parser": "1.20.4",
+    "bunyan": "^1.8.15",
+    "express": "^4.22.1",
+    "p-limit": "^3.1.0",
+    "tar-fs": "^3.1.1"
+  },
+  "devDependencies": {
+    "chai": "^4.3.6",
+    "chai-as-promised": "^7.1.1",
+    "mocha": "^11.1.0",
+    "mocha-junit-reporter": "^2.2.1",
+    "mocha-multi-reporters": "^1.5.1"
+  },
+  "version": "1.0.0",
+  "directories": {
+    "test": "test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "AGPL-3.0"
+}

--- a/services/clsi-cache/test/setup.js
+++ b/services/clsi-cache/test/setup.js
@@ -1,0 +1,19 @@
+// Settings are read once on import, so the test environment has to be in
+// place before any module of the service is loaded.
+import fs from 'node:fs'
+import os from 'node:os'
+import Path from 'node:path'
+
+const root = fs.mkdtempSync(Path.join(os.tmpdir(), 'clsi-cache-test-'))
+process.env.CLSI_CACHE_DATA_PATH = Path.join(root, 'cache')
+process.env.CLSI_CACHE_LOCAL_CLSI_OUTPUT_DIR = Path.join(root, 'clsi-output')
+process.env.CLSI_CACHE_SHARD = 'clsi-cache-test'
+process.env.CLSI_CACHE_SWEEP_INTERVAL_MS = '0'
+process.env.LOG_LEVEL = 'fatal'
+
+fs.mkdirSync(process.env.CLSI_CACHE_DATA_PATH, { recursive: true })
+fs.mkdirSync(process.env.CLSI_CACHE_LOCAL_CLSI_OUTPUT_DIR, { recursive: true })
+
+process.on('exit', () => {
+  fs.rmSync(root, { recursive: true, force: true })
+})

--- a/services/clsi-cache/test/unit/js/BuildStore.test.js
+++ b/services/clsi-cache/test/unit/js/BuildStore.test.js
@@ -1,0 +1,94 @@
+import { expect } from 'chai'
+import { Readable } from 'node:stream'
+import * as BuildStore from '../../../app/js/BuildStore.js'
+import { generateBuildId } from '../../../app/js/utils.js'
+
+const EDITOR_ID = '11111111-2222-4333-8444-555555555555'
+const PROJECT_KEY = 'aaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbbbbbbbbbb'
+
+async function putBuild(projectKey, timestamp, files) {
+  const editorBuildId = `${EDITOR_ID}-${generateBuildId(timestamp)}`
+  const prefix = BuildStore.buildPrefix(projectKey, editorBuildId)
+  for (const [name, content] of Object.entries(files)) {
+    await BuildStore.sendStream(
+      `${prefix}/${name}`,
+      Readable.from([Buffer.from(content)])
+    )
+  }
+  return { editorBuildId, prefix }
+}
+
+describe('BuildStore', function () {
+  beforeEach(async function () {
+    await BuildStore.deleteDirectory(BuildStore.projectPrefix(PROJECT_KEY))
+  })
+
+  it('lists builds newest first with their files', async function () {
+    const older = await putBuild(PROJECT_KEY, 1_000, { 'output.pdf': 'a' })
+    const newer = await putBuild(PROJECT_KEY, 2_000, {
+      'output.pdf': 'bb',
+      'output.log': 'log',
+      'sub/refs.blg': 'blg',
+    })
+
+    const builds = await BuildStore.listBuilds(PROJECT_KEY)
+    expect(builds.map(b => b.editorBuildId)).to.deep.equal([
+      newer.editorBuildId,
+      older.editorBuildId,
+    ])
+    expect(builds[0].timestamp).to.equal(2_000)
+    expect(builds[0].files).to.deep.equal([
+      'output.log',
+      'output.pdf',
+      'sub/refs.blg',
+    ])
+  })
+
+  it('finds the latest build that has a given file', async function () {
+    const withTar = await putBuild(PROJECT_KEY, 1_000, {
+      'output.pdf': 'a',
+      'output.tar.gz': 'tar',
+    })
+    const pdfOnly = await putBuild(PROJECT_KEY, 2_000, { 'output.pdf': 'b' })
+
+    const latestPdf = await BuildStore.findLatestBuild(PROJECT_KEY, 'output.pdf')
+    expect(latestPdf.editorBuildId).to.equal(pdfOnly.editorBuildId)
+
+    const latestTar = await BuildStore.findLatestBuild(
+      PROJECT_KEY,
+      'output.tar.gz'
+    )
+    expect(latestTar.editorBuildId).to.equal(withTar.editorBuildId)
+
+    expect(await BuildStore.findLatestBuild(PROJECT_KEY, 'output.log')).to.equal(
+      undefined
+    )
+  })
+
+  it('reports sizes and streams ranges', async function () {
+    const { prefix } = await putBuild(PROJECT_KEY, 1_000, {
+      'output.pdf': '0123456789',
+    })
+    const key = `${prefix}/output.pdf`
+    expect(await BuildStore.getObjectSize(key)).to.equal(10)
+    const stream = await BuildStore.getObjectStream(key, { start: 2, end: 4 })
+    const chunks = []
+    for await (const chunk of stream) chunks.push(chunk)
+    expect(Buffer.concat(chunks).toString()).to.equal('234')
+  })
+
+  it('copies a build to another prefix and lists project keys', async function () {
+    const { prefix } = await putBuild(PROJECT_KEY, 1_000, {
+      'output.pdf': 'a',
+      'output.overleaf.json': '{"size":1}',
+    })
+    const dst = BuildStore.templatePrefix('tmpl-v1', 'texlive-full:2026.1')
+    const copied = await BuildStore.copyPrefix(prefix, dst)
+    expect(copied).to.deep.equal(['output.overleaf.json', 'output.pdf'])
+    expect(await BuildStore.readJSON(`${dst}/output.overleaf.json`)).to.deep.equal(
+      { size: 1 }
+    )
+    expect(await BuildStore.listProjectKeys()).to.include(PROJECT_KEY)
+    await BuildStore.deleteDirectory(dst)
+  })
+})

--- a/services/clsi-cache/test/unit/js/IngestManager.test.js
+++ b/services/clsi-cache/test/unit/js/IngestManager.test.js
@@ -1,0 +1,121 @@
+import { expect } from 'chai'
+import fs from 'node:fs'
+import Path from 'node:path'
+import Settings from '@overleaf/settings'
+import * as BuildStore from '../../../app/js/BuildStore.js'
+import * as IngestManager from '../../../app/js/IngestManager.js'
+import { generateBuildId } from '../../../app/js/utils.js'
+
+const EDITOR_ID = '11111111-2222-4333-8444-555555555555'
+const PROJECT_ID = 'aaaaaaaaaaaaaaaaaaaaaaaa'
+const USER_ID = 'bbbbbbbbbbbbbbbbbbbbbbbb'
+
+function writeClsiOutput(buildId, files) {
+  const dir = Path.join(
+    Settings.path.localClsiOutputDir,
+    `${PROJECT_ID}-${USER_ID}`,
+    'generated-files',
+    buildId
+  )
+  for (const [name, content] of Object.entries(files)) {
+    const path = Path.join(dir, name)
+    fs.mkdirSync(Path.dirname(path), { recursive: true })
+    fs.writeFileSync(path, content)
+  }
+  return dir
+}
+
+function job(buildId, files) {
+  return {
+    projectId: PROJECT_ID,
+    userId: USER_ID,
+    buildId,
+    editorId: EDITOR_ID,
+    files,
+    downloadHost: 'http://127.0.0.1:1',
+    clsiServerId: 'clsi-test',
+    compileGroup: 'standard',
+    stats: { a: 1 },
+    timings: { b: 2 },
+    options: { compiler: 'pdflatex', imageName: 'texlive-full:2026.1' },
+  }
+}
+
+describe('IngestManager (local clsi output dir)', function () {
+  beforeEach(async function () {
+    await BuildStore.deleteDirectory(
+      BuildStore.projectPrefix(`${PROJECT_ID}-${USER_ID}`)
+    )
+  })
+
+  it('hard-links the outputs and writes the meta file after the pdf', async function () {
+    const buildId = generateBuildId()
+    const dir = writeClsiOutput(buildId, {
+      'output.pdf': '%PDF-1.7',
+      'output.log': 'log',
+      'nested/custom.blg': 'blg',
+    })
+
+    const prefix = IngestManager.enqueue(
+      job(buildId, [
+        { path: 'output.pdf', size: 8, contentId: 'c1', ranges: [] },
+        { path: 'output.log' },
+        { path: 'nested/custom.blg' },
+      ])
+    )
+    expect(IngestManager.isInflight(prefix)).to.equal(true)
+    expect(await IngestManager.waitForBuild(prefix, 5_000)).to.equal(true)
+
+    const files = await BuildStore.listFiles(prefix)
+    expect(files).to.deep.equal([
+      'nested/custom.blg',
+      'output.log',
+      'output.overleaf.json',
+      'output.pdf',
+    ])
+    // Same inode: no second copy of the PDF on disk.
+    const src = fs.statSync(Path.join(dir, 'output.pdf'))
+    const dst = fs.statSync(BuildStore.fsPath(`${prefix}/output.pdf`))
+    expect(dst.ino).to.equal(src.ino)
+    expect(src.nlink).to.equal(2)
+
+    const meta = await BuildStore.readJSON(`${prefix}/output.overleaf.json`)
+    expect(meta).to.deep.equal({
+      ranges: [],
+      contentId: 'c1',
+      size: 8,
+      clsiServerId: 'clsi-test',
+      compileGroup: 'standard',
+      options: { compiler: 'pdflatex', imageName: 'texlive-full:2026.1' },
+      stats: { a: 1 },
+      timings: { b: 2 },
+    })
+  })
+
+  it('survives clsi expiring its copy', async function () {
+    const buildId = generateBuildId()
+    const dir = writeClsiOutput(buildId, { 'output.pdf': 'keep me' })
+    const prefix = IngestManager.enqueue(
+      job(buildId, [{ path: 'output.pdf', size: 7 }])
+    )
+    await IngestManager.waitForBuild(prefix, 5_000)
+
+    fs.rmSync(dir, { recursive: true, force: true })
+    const stream = await BuildStore.getObjectStream(`${prefix}/output.pdf`)
+    const chunks = []
+    for await (const chunk of stream) chunks.push(chunk)
+    expect(Buffer.concat(chunks).toString()).to.equal('keep me')
+  })
+
+  it('does not write the meta file when the pdf is missing', async function () {
+    const buildId = generateBuildId()
+    writeClsiOutput(buildId, { 'output.log': 'log' })
+    // output.pdf is neither on disk nor reachable via the download host.
+    const prefix = IngestManager.enqueue(
+      job(buildId, [{ path: 'output.pdf', size: 1 }, { path: 'output.log' }])
+    )
+    await IngestManager.waitForBuild(prefix, 5_000)
+
+    expect(await BuildStore.listFiles(prefix)).to.deep.equal(['output.log'])
+  })
+})

--- a/services/clsi-cache/test/unit/js/utils.test.js
+++ b/services/clsi-cache/test/unit/js/utils.test.js
@@ -1,0 +1,76 @@
+import { expect } from 'chai'
+import {
+  generateBuildId,
+  getBuildTimestamp,
+  getProjectKey,
+  isAllowedFilename,
+  splitEditorBuildId,
+  validateFilename,
+  EDITOR_BUILD_ID_REGEX,
+} from '../../../app/js/utils.js'
+import { InvalidNameError } from '../../../app/js/Errors.js'
+
+describe('utils', function () {
+  describe('isAllowedFilename', function () {
+    it('accepts the fixed output files', function () {
+      for (const name of [
+        'output.pdf',
+        'output.log',
+        'output.synctex.gz',
+        'output.overleaf.json',
+        'output.tar.gz',
+        'history-resync.json.gz',
+      ]) {
+        expect(isAllowedFilename(name), name).to.equal(true)
+      }
+    })
+
+    it('accepts nested .blg files with custom names', function () {
+      expect(isAllowedFilename('chapters/refs.blg')).to.equal(true)
+    })
+
+    it('rejects everything else', function () {
+      expect(isAllowedFilename('output.aux')).to.equal(false)
+      expect(isAllowedFilename('main.tex')).to.equal(false)
+    })
+  })
+
+  describe('validateFilename', function () {
+    it('rejects path traversal before the allow-list', function () {
+      expect(() => validateFilename('../output.pdf')).to.throw(InvalidNameError)
+      expect(() => validateFilename('a/../b.blg')).to.throw(InvalidNameError)
+    })
+
+    it('rejects names outside the allow-list', function () {
+      expect(() => validateFilename('output.aux')).to.throw(InvalidNameError)
+    })
+  })
+
+  describe('build ids', function () {
+    it('round-trips the timestamp through the build id', function () {
+      const ts = 1_700_000_000_000
+      const buildId = generateBuildId(ts)
+      expect(getBuildTimestamp(buildId)).to.equal(ts)
+      expect(`00000000-0000-4000-8000-000000000000-${buildId}`).to.match(
+        EDITOR_BUILD_ID_REGEX
+      )
+    })
+
+    it('splits editorId and buildId', function () {
+      const editorId = '00000000-0000-4000-8000-000000000000'
+      const buildId = '18f0c0ffee-0123456789abcdef'
+      expect(splitEditorBuildId(`${editorId}-${buildId}`)).to.deep.equal({
+        editorId,
+        buildId,
+      })
+    })
+  })
+
+  describe('getProjectKey', function () {
+    it('matches the clsi directory layout', function () {
+      expect(getProjectKey('p', 'u')).to.equal('p-u')
+      expect(getProjectKey('p')).to.equal('p')
+      expect(getProjectKey('p', undefined)).to.equal('p')
+    })
+  })
+})

--- a/services/clsi/app/js/CLSICacheHandler.js
+++ b/services/clsi/app/js/CLSICacheHandler.js
@@ -195,7 +195,10 @@ function notifyCLSICacheAboutBuild({
   }
 
   const isUserCompile = !metricsOpts.path
-  if (!(isUserCompile && compileGroup === 'standard')) {
+  if (
+    Settings.apis.clsiCache.populateForStandardCompiles ||
+    !(isUserCompile && compileGroup === 'standard')
+  ) {
     // PDF preview, skip for free compiles
     enqueue(
       outputFiles

--- a/services/clsi/config/settings.defaults.cjs
+++ b/services/clsi/config/settings.defaults.cjs
@@ -77,6 +77,9 @@ module.exports = {
       ),
       currentShards: parseInt(process.env.CLSI_CACHE_CURRENT_SHARDS, 10),
       desiredShards: parseInt(process.env.CLSI_CACHE_DESIRED_SHARDS, 10),
+      // Outside of SaaS there are no free compiles to save the PDF upload on.
+      populateForStandardCompiles:
+        process.env.CLSI_CACHE_POPULATE_FOR_STANDARD_COMPILES !== 'false',
       reshardFrom: new Date(process.env.CLSI_CACHE_RESHARD_FROM),
       reshardUntil: new Date(process.env.CLSI_CACHE_RESHARD_UNTIL),
     },

--- a/services/web/app/src/Features/Compile/ClsiCacheController.mjs
+++ b/services/web/app/src/Features/Compile/ClsiCacheController.mjs
@@ -189,7 +189,7 @@ async function getLatestBuildFromCache(req, res) {
 
     let { pdfCachingMinChunkSize, pdfDownloadDomain } =
       await CompileController._getSplitTestOptions(req, res)
-    pdfDownloadDomain += `/zone/${zone}`
+    if (pdfDownloadDomain) pdfDownloadDomain += `/zone/${zone}`
     res.json({
       fromCache: true,
       status: 'success',

--- a/services/web/app/src/Features/Compile/ClsiCacheHandler.mjs
+++ b/services/web/app/src/Features/Compile/ClsiCacheHandler.mjs
@@ -79,7 +79,7 @@ function getEgressLabel(fsPath) {
  * @return {Promise<void>}
  */
 async function clearCache(projectId, userId) {
-  if (!Features.hasFeature('saas')) return
+  if (!Settings.apis.clsiCache.enabled) return
 
   let path = `/project/${projectId}`
   if (userId) {

--- a/services/web/app/src/Features/Compile/ClsiCacheManager.mjs
+++ b/services/web/app/src/Features/Compile/ClsiCacheManager.mjs
@@ -204,9 +204,11 @@ async function prepareClsiCache(
   userId,
   { sourceProjectId, templateVersionId, imageName }
 ) {
-  if (!Features.hasFeature('saas')) return undefined
-  const features = await UserGetter.promises.getUserFeatures(userId)
-  if (features.compileGroup !== 'priority') return undefined
+  if (!Settings.apis.clsiCache.enabled) return undefined
+  if (Features.hasFeature('saas')) {
+    const features = await UserGetter.promises.getUserFeatures(userId)
+    if (features.compileGroup !== 'priority') return undefined
+  }
 
   const signal = AbortSignal.timeout(ClsiCacheHandler.TIMEOUT)
   let lastUpdated

--- a/services/web/app/src/Features/Compile/ClsiManager.mjs
+++ b/services/web/app/src/Features/Compile/ClsiManager.mjs
@@ -7,6 +7,7 @@ import {
   RequestFailedError,
 } from '@overleaf/fetch-utils'
 import Settings from '@overleaf/settings'
+import Features from '../../infrastructure/Features.mjs'
 import ProjectGetter from '../Project/ProjectGetter.mjs'
 import ProjectEntityHandler from '../Project/ProjectEntityHandler.mjs'
 import logger from '@overleaf/logger'
@@ -1155,7 +1156,9 @@ function _finaliseRequest(projectId, options, project, docs, files) {
           // enable for premium compiles
           (['alpha', 'priority'].includes(options.compileGroup) ||
             // enable for free for short period when we saw low capacity
-            enableCompileFromCacheUntil > Date.now()) &&
+            enableCompileFromCacheUntil > Date.now() ||
+            // no premium tiers outside of SaaS
+            !Features.hasFeature('saas')) &&
           options.compileFromClsiCache,
         populateClsiCache: options.populateClsiCache,
         enablePdfCaching:
@@ -1236,7 +1239,9 @@ async function syncTeX(
   )
   url.searchParams.set(
     'compileFromClsiCache',
-    compileFromClsiCache && ['alpha', 'priority'].includes(compileGroup)
+    compileFromClsiCache &&
+      (!Features.hasFeature('saas') ||
+        ['alpha', 'priority'].includes(compileGroup))
   )
   url.searchParams.set('imageName', imageName)
   for (const [key, value] of Object.entries(validatedOptions)) {

--- a/services/web/app/src/Features/Compile/CompileController.mjs
+++ b/services/web/app/src/Features/Compile/CompileController.mjs
@@ -85,7 +85,7 @@ async function _syncTeX(req, res, direction, validatedOptions) {
   try {
     const body = await CompileManager.promises.syncTeX(projectId, userId, {
       direction,
-      compileFromClsiCache: Features.hasFeature('saas'),
+      compileFromClsiCache: Settings.apis.clsiCache.enabled,
       validatedOptions: {
         ...validatedOptions,
         editorId,
@@ -207,9 +207,11 @@ const _CompileController = {
       pdfDownloadDomain,
       compileFromHistory,
     } = await _getSplitTestOptions(req, res)
-    if (Features.hasFeature('saas')) {
+    if (Settings.apis.clsiCache.enabled) {
       options.compileFromClsiCache = true
       options.populateClsiCache = true
+    }
+    if (Features.hasFeature('saas')) {
       options.compileFromHistory = compileFromHistory
     }
     options.enablePdfCaching = enablePdfCaching

--- a/services/web/app/src/Features/Project/ProjectController.mjs
+++ b/services/web/app/src/Features/Project/ProjectController.mjs
@@ -939,8 +939,9 @@ const _ProjectController = {
         project_id: project._id,
         projectName: project.name,
         canUseClsiCache:
-          Features.hasFeature('saas') &&
-          ownerFeatures?.compileGroup === 'priority',
+          Settings.apis.clsiCache.enabled &&
+          (!Features.hasFeature('saas') ||
+            ownerFeatures?.compileGroup === 'priority'),
         user: {
           id: userId,
           email: user.email,

--- a/services/web/config/settings.defaults.js
+++ b/services/web/config/settings.defaults.js
@@ -257,6 +257,7 @@ module.exports = {
     },
     clsiCache: {
       instances: JSON.parse(process.env.CLSI_CACHE_INSTANCES || '[]'),
+      enabled: Boolean(process.env.CLSI_CACHE_INSTANCES),
     },
     project_history: {
       sendProjectStructureOps: true,


### PR DESCRIPTION
- Add IngestManager.js to manage the ingestion of build files from CLSI.
- Implement file validation and ingestion logic, including local disk imports and downloads from CLSI.
- Introduce metadata writing for ingested builds.
- Create Persistor.js for object persistence settings.
- Add utility functions in utils.js for filename validation and project key generation.
- Establish settings defaults for clsi-cache configuration.
- Create buildscript.txt for service configuration.
- Implement tests for IngestManager and utility functions.
- Update CLSICacheHandler to notify about builds based on new settings.
- Modify ClsiManager and related components to integrate with the new caching mechanism.

## Description

<!-- Goal of the pull request -->

Before: every time you open a project, it recompiles.

https://github.com/user-attachments/assets/fa49ca46-5b28-47bd-aa9e-1c6907a1b3a1

After: (Same as SaaS, need paid subscriptions)

https://github.com/user-attachments/assets/d8bbd12b-e551-49a4-867f-ef963d96458c


## Related issues / Pull Requests

<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
