### PR TITLE
Feature(open-in-overleaf): add the Overleaf API (/docs) and /devs page

### DIFF
--- a/services/web/config/settings.defaults.js
+++ b/services/web/config/settings.defaults.js
@@ -1253,7 +1253,8 @@ module.exports = {
     'git-bridge',
     'github-sync',
     'tpr-webmodule',
-    'instance-features'
+    'instance-features',
+    'open-in-overleaf'
   ],
   viewIncludes: {},
 

--- a/services/web/modules/open-in-overleaf/app/src/OpenInOverleafController.mjs
+++ b/services/web/modules/open-in-overleaf/app/src/OpenInOverleafController.mjs
@@ -1,15 +1,22 @@
 import Path from 'node:path'
+import crypto from 'node:crypto'
 import archiver from 'archiver'
 import { fileURLToPath } from 'node:url'
 import settings from '@overleaf/settings'
 import logger from '@overleaf/logger'
 import { expressify } from '@overleaf/promise-utils'
 import SessionManager from '../../../../app/src/Features/Authentication/SessionManager.mjs'
+import RedisWrapper from '../../../../app/src/infrastructure/RedisWrapper.mjs'
 import OpenInOverleafManager, {
   OpenInOverleafError,
 } from './OpenInOverleafManager.mjs'
 
 const __dirname = Path.dirname(fileURLToPath(import.meta.url))
+
+const rclient = RedisWrapper.client('open_in_overleaf')
+const RESUME_TTL_SECONDS = 10 * 60
+const RESUME_TOKEN_REGEX = /^[0-9a-f-]{36}$/
+const resumeKey = token => `open-in-overleaf:resume:${token}`
 
 function toArray(value) {
   if (value == null) return []
@@ -57,11 +64,45 @@ function parseParams(req) {
   }
 }
 
+// POST /docs from a signed-out browser, or a cross-site form whose SameSite=Lax
+// session cookie is not sent: requireLogin would redirect to /login keeping
+// only the path, dropping the body. Park the submission in redis and redirect
+// to a GET carrying the token; the cookie-bearing top-level GET (or the login
+// round trip) then resumes with the full input. Nothing is written to
+// req.session here on purpose: a fresh session cookie in this response would
+// overwrite the browser's existing login.
+async function stashForLogin(req, res, next) {
+  if (SessionManager.isUserLoggedIn(req.session)) return next()
+  const token = crypto.randomUUID()
+  await rclient.setex(
+    resumeKey(token),
+    RESUME_TTL_SECONDS,
+    JSON.stringify(parseParams(req))
+  )
+  res.redirect(`/docs?resume=${token}`)
+}
+
+async function loadResumedParams(token) {
+  const key = resumeKey(token)
+  // single use: read and delete atomically
+  const [json] = await rclient.multi().get(key).del(key).exec()
+  if (!json) {
+    throw new OpenInOverleafError(
+      'This Open in Overleaf link has expired, please submit it again.'
+    )
+  }
+  return JSON.parse(json)
+}
+
 async function openInOverleaf(req, res) {
   const ownerId = SessionManager.getLoggedInUserId(req.session)
-  const params = parseParams(req)
 
   try {
+    const { resume } = req.query
+    const params =
+      typeof resume === 'string' && RESUME_TOKEN_REGEX.test(resume)
+        ? await loadResumedParams(resume)
+        : parseParams(req)
     const project = await OpenInOverleafManager.createProject(params, ownerId)
     return res.redirect(`/project/${project._id}`)
   } catch (err) {
@@ -144,6 +185,7 @@ async function devsPage(req, res) {
 }
 
 export default {
+  stashForLogin: expressify(stashForLogin),
   openInOverleaf: expressify(openInOverleaf),
   devsPage: expressify(devsPage),
 }

--- a/services/web/modules/open-in-overleaf/app/src/OpenInOverleafController.mjs
+++ b/services/web/modules/open-in-overleaf/app/src/OpenInOverleafController.mjs
@@ -1,0 +1,149 @@
+import Path from 'node:path'
+import archiver from 'archiver'
+import { fileURLToPath } from 'node:url'
+import settings from '@overleaf/settings'
+import logger from '@overleaf/logger'
+import { expressify } from '@overleaf/promise-utils'
+import SessionManager from '../../../../app/src/Features/Authentication/SessionManager.mjs'
+import OpenInOverleafManager, {
+  OpenInOverleafError,
+} from './OpenInOverleafManager.mjs'
+
+const __dirname = Path.dirname(fileURLToPath(import.meta.url))
+
+function toArray(value) {
+  if (value == null) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+function firstString(value) {
+  const v = Array.isArray(value) ? value[0] : value
+  return typeof v === 'string' && v.length ? v : undefined
+}
+
+// snip_uri / snip_uri[] (+ matching snip_name / snip_name[]) → [{ url, name }].
+function normalizeUris(uris, names) {
+  const urlList = toArray(uris).filter(u => typeof u === 'string' && u.length)
+  const nameList = toArray(names)
+  return urlList.map((url, i) => ({
+    url,
+    name: typeof nameList[i] === 'string' ? nameList[i] : undefined,
+  }))
+}
+
+// Accept the API parameters from either a POST body or a GET query string,
+// mirroring the official /docs endpoint.
+function parseParams(req) {
+  const src = { ...req.query, ...req.body }
+
+  let snippet = null
+  if (src.encoded_snip != null) {
+    try {
+      snippet = decodeURIComponent(src.encoded_snip)
+    } catch (e) {
+      snippet = String(src.encoded_snip)
+    }
+  } else if (src.snip != null) {
+    snippet = String(src.snip)
+  }
+
+  return {
+    snippet,
+    snipUris: normalizeUris(src.snip_uri, src.snip_name),
+    zipUri: firstString(src.zip_uri),
+    engine: firstString(src.engine),
+    mainDocument: firstString(src.main_document),
+    projectName: firstString(src.name) || firstString(src.project_name),
+  }
+}
+
+async function openInOverleaf(req, res) {
+  const ownerId = SessionManager.getLoggedInUserId(req.session)
+  const params = parseParams(req)
+
+  try {
+    const project = await OpenInOverleafManager.createProject(params, ownerId)
+    return res.redirect(`/project/${project._id}`)
+  } catch (err) {
+    logger.warn({ err }, 'open-in-overleaf: failed to create project')
+    const message =
+      err instanceof OpenInOverleafError
+        ? err.message
+        : 'Sorry, something went wrong loading this project into Overleaf.'
+    return res.status(422).render(Path.resolve(__dirname, '../views/error'), {
+      title: 'Open in Overleaf',
+      message,
+    })
+  }
+}
+
+// A minimal multi-file project, zipped in memory once at startup so the /devs
+// page can offer a working "zipped project" example without a binary fixture.
+function buildZip(files) {
+  return new Promise((resolve, reject) => {
+    const archive = archiver('zip', { zlib: { level: 9 } })
+    const chunks = []
+    archive.on('data', chunk => chunks.push(chunk))
+    archive.on('error', reject)
+    archive.on('end', () => resolve(Buffer.concat(chunks)))
+    for (const [name, content] of Object.entries(files)) {
+      archive.append(content, { name })
+    }
+    archive.finalize()
+  })
+}
+
+// The same three files as the example archive on the official /devs page.
+const demoZipB64 = buildZip({
+  'main.tex': [
+    '\\documentclass{article}',
+    '\\usepackage{subfiles}',
+    '\\title{I am a Zip file}',
+    '\\author{Overleaf}',
+    '\\date{June 2023}',
+    '\\begin{document}',
+    '\\maketitle',
+    '\\section{Introduction}',
+    '\\subfile{main2}',
+    '\\subsection{How to add Citations and a References List}',
+    'Citation example: \\cite{greenwade93}',
+    '\\bibliographystyle{alpha}',
+    '\\bibliography{sample}',
+    '\\end{document}',
+    '',
+  ].join('\n'),
+  'sample.bib': [
+    '@article{greenwade93,',
+    '    author  = "George D. Greenwade",',
+    '    title   = "The {C}omprehensive {T}ex {A}rchive {N}etwork ({CTAN})",',
+    '    year    = "1993",',
+    '    journal = "TUGBoat",',
+    '    volume  = "14",',
+    '    number  = "3",',
+    '    pages   = "342--351"',
+    '}',
+    '',
+  ].join('\n'),
+  'main2.tex': [
+    '\\documentclass[./main.tex]{subfiles}',
+    '\\begin{document}',
+    '\\textbf{Hello from another file!}',
+    '\\end{document}',
+    '',
+  ].join('\n'),
+}).then(buffer => buffer.toString('base64'))
+
+// The /devs documentation page ("Overleaf API").
+async function devsPage(req, res) {
+  const baseUrl = settings.siteUrl || `${req.protocol}://${req.get('host')}`
+  res.render(Path.resolve(__dirname, '../views/devs'), {
+    title: 'Overleaf API',
+    olBaseUrl: baseUrl,
+    olDemoZipB64: await demoZipB64,
+  })
+}
+
+export default {
+  openInOverleaf: expressify(openInOverleaf),
+  devsPage: expressify(devsPage),
+}

--- a/services/web/modules/open-in-overleaf/app/src/OpenInOverleafManager.mjs
+++ b/services/web/modules/open-in-overleaf/app/src/OpenInOverleafManager.mjs
@@ -31,6 +31,8 @@ const DEFAULT_PROJECT_NAME = 'Open in Overleaf project'
 // Generous: the proxy already applies its own 30s timeout per hop, and a
 // redirect chain plus a slow origin must not be cut off by us first.
 const FETCH_TIMEOUT_MS = 60 * 1000
+// Upper bound on snip_uri[] entries; each is a remote download.
+const MAX_SNIP_URIS = 50
 
 class OpenInOverleafError extends Error {}
 
@@ -64,30 +66,34 @@ function looksLikeZip(buffer) {
   return buffer.subarray(0, 4).equals(ZIP_MAGIC)
 }
 
-function tooLarge(what, maxBytes) {
+function tooLarge(what) {
+  const mb = Math.round(settings.maxUploadSize / 1024 / 1024)
   return new OpenInOverleafError(
-    `${what} is larger than the ${Math.round(maxBytes / 1024 / 1024)} MB limit`
+    `${what} exceeds the ${mb} MB upload limit (all files combined)`
   )
 }
 
-// File name for an uploaded snippet: snip_name[] if given, otherwise the last
-// path segment of the URL, otherwise a numbered default. Directory parts are
-// dropped so a name can never escape the project root inside the zip.
+function cleanFileName(candidate) {
+  if (typeof candidate !== 'string') return undefined
+  // Directory parts are dropped so a name can never escape the project root.
+  const base = Path.posix.basename(candidate.replace(/\\/g, '/')).trim()
+  return base && base !== '.' && base !== '..' ? base : undefined
+}
+
+// File name for an uploaded snippet: snip_name[] if given (explicit), otherwise
+// the last path segment of the URL, otherwise a numbered default.
 function safeFileName(name, url, index) {
-  const candidates = [name]
+  const explicit = cleanFileName(name)
+  if (explicit) return { name: explicit, explicit: true }
   if (/^https?:\/\//i.test(url)) {
     try {
-      candidates.push(decodeURIComponent(new URL(url).pathname))
+      const fromUrl = cleanFileName(decodeURIComponent(new URL(url).pathname))
+      if (fromUrl) return { name: fromUrl, explicit: false }
     } catch (e) {
       // unparsable url, fall through to the default name
     }
   }
-  for (const candidate of candidates) {
-    if (typeof candidate !== 'string') continue
-    const base = Path.posix.basename(candidate.replace(/\\/g, '/')).trim()
-    if (base && base !== '.' && base !== '..') return base
-  }
-  return `snippet-${index + 1}.tex`
+  return { name: `snippet-${index + 1}.tex`, explicit: false }
 }
 
 // Decode a `data:[<mime>][;base64],<payload>` URL into a Buffer.
@@ -117,7 +123,7 @@ function decodeDataUrl(url, maxBytes) {
     buffer = Buffer.from(payload, 'utf8')
   }
   if (buffer.length > maxBytes) {
-    throw tooLarge('data url', maxBytes)
+    throw tooLarge('data url')
   }
   return buffer
 }
@@ -129,7 +135,7 @@ async function readStreamToBuffer(stream, maxBytes, what) {
     size += chunk.length
     if (size > maxBytes) {
       stream.destroy()
-      throw tooLarge(what, maxBytes)
+      throw tooLarge(what)
     }
     chunks.push(chunk)
   }
@@ -138,8 +144,8 @@ async function readStreamToBuffer(stream, maxBytes, what) {
 
 // Fetch a snippet/zip URL into a Buffer. http(s) go through the SSRF proxy;
 // data: URLs are decoded locally.
-async function fetchUrlToBuffer(rawUrl) {
-  const maxBytes = settings.maxUploadSize
+// maxBytes lets callers importing several files share one upload budget.
+async function fetchUrlToBuffer(rawUrl, maxBytes = settings.maxUploadSize) {
   if (/^data:/i.test(rawUrl)) {
     return decodeDataUrl(rawUrl, maxBytes)
   }
@@ -171,6 +177,21 @@ async function fetchUrlToBuffer(rawUrl) {
     throw err
   }
   return await readStreamToBuffer(stream, maxBytes, url)
+}
+
+// Zip a set of in-memory files and import them, keeping their names (so
+// main_document can refer to them).
+async function importFilesAsZip(files, ownerId, projectName) {
+  const zipPath = await buildZipFromFiles(files)
+  try {
+    return await ProjectUploadManager.promises.createProjectFromZipArchive(
+      ownerId,
+      projectName,
+      zipPath
+    )
+  } finally {
+    fs.promises.unlink(zipPath).catch(() => {})
+  }
 }
 
 async function importZipBuffer(buffer, ownerId, projectName) {
@@ -257,12 +278,22 @@ const OpenInOverleafManager = {
   },
 
   async _createFromUrls(snipUris, ownerId, projectName) {
+    if (snipUris.length > MAX_SNIP_URIS) {
+      throw new OpenInOverleafError(
+        `too many snip_uri entries (maximum ${MAX_SNIP_URIS})`
+      )
+    }
+
+    // All files of one submission share the single upload budget, so a request
+    // cannot multiply the limit by listing many URLs.
+    let remaining = settings.maxUploadSize
     const files = []
     for (const [index, { url, name }] of snipUris.entries()) {
-      const buffer = await fetchUrlToBuffer(url)
+      const buffer = await fetchUrlToBuffer(url, remaining)
+      remaining -= buffer.length
       files.push({
         buffer,
-        name: safeFileName(name, url, index),
+        ...safeFileName(name, url, index),
         isZip: looksLikeZip(buffer),
       })
     }
@@ -272,12 +303,16 @@ const OpenInOverleafManager = {
       if (file.isZip) {
         return await importZipBuffer(file.buffer, ownerId, projectName)
       }
-      // A single .tex file → straight snippet project (keeps the nice main.tex).
-      return await ProjectCreationHandler.promises.createProjectFromSnippet(
-        ownerId,
-        projectName,
-        prepareSnippet(file.buffer.toString('utf8')).split('\n')
-      )
+      if (!file.explicit) {
+        // A single .tex file → straight snippet project as main.tex.
+        return await ProjectCreationHandler.promises.createProjectFromSnippet(
+          ownerId,
+          projectName,
+          prepareSnippet(file.buffer.toString('utf8')).split('\n')
+        )
+      }
+      // snip_name given: import under that name so main_document can select it.
+      return await importFilesAsZip(files, ownerId, projectName)
     }
 
     if (files.some(file => file.isZip)) {
@@ -285,18 +320,7 @@ const OpenInOverleafManager = {
         'a zip archive must be the only snip_uri; use zip_uri for projects'
       )
     }
-
-    // Multiple files → zip them up and import as one project.
-    const zipPath = await buildZipFromFiles(files)
-    try {
-      return await ProjectUploadManager.promises.createProjectFromZipArchive(
-        ownerId,
-        projectName,
-        zipPath
-      )
-    } finally {
-      fs.promises.unlink(zipPath).catch(() => {})
-    }
+    return await importFilesAsZip(files, ownerId, projectName)
   },
 
   async _applyOptions(project, params) {

--- a/services/web/modules/open-in-overleaf/app/src/OpenInOverleafManager.mjs
+++ b/services/web/modules/open-in-overleaf/app/src/OpenInOverleafManager.mjs
@@ -179,29 +179,42 @@ async function fetchUrlToBuffer(rawUrl, maxBytes = settings.maxUploadSize) {
   return await readStreamToBuffer(stream, maxBytes, url)
 }
 
+// createProjectFromZipArchive names the project from the archive's \title
+// (projectName is only a fallback); createProjectFromZipArchiveWithName forces
+// the given name and returns a richer object. Pick per preserveName — set when
+// the caller gave an explicit name — and always return the project.
+async function importZipArchive(ownerId, projectName, zipPath, preserveName) {
+  if (preserveName) {
+    const { project } =
+      await ProjectUploadManager.promises.createProjectFromZipArchiveWithName(
+        ownerId,
+        projectName,
+        zipPath
+      )
+    return project
+  }
+  return await ProjectUploadManager.promises.createProjectFromZipArchive(
+    ownerId,
+    projectName,
+    zipPath
+  )
+}
+
 // Zip a set of in-memory files and import them, keeping their names (so
 // main_document can refer to them).
-async function importFilesAsZip(files, ownerId, projectName) {
+async function importFilesAsZip(files, ownerId, projectName, preserveName) {
   const zipPath = await buildZipFromFiles(files)
   try {
-    return await ProjectUploadManager.promises.createProjectFromZipArchive(
-      ownerId,
-      projectName,
-      zipPath
-    )
+    return await importZipArchive(ownerId, projectName, zipPath, preserveName)
   } finally {
     fs.promises.unlink(zipPath).catch(() => {})
   }
 }
 
-async function importZipBuffer(buffer, ownerId, projectName) {
+async function importZipBuffer(buffer, ownerId, projectName, preserveName) {
   const path = await writeBufferToDump(buffer, '.zip')
   try {
-    return await ProjectUploadManager.promises.createProjectFromZipArchive(
-      ownerId,
-      projectName,
-      path
-    )
+    return await importZipArchive(ownerId, projectName, path, preserveName)
   } finally {
     fs.promises.unlink(path).catch(() => {})
   }
@@ -238,6 +251,9 @@ const OpenInOverleafManager = {
   //   engine?, mainDocument?, projectName?
   // }
   async createProject(params, ownerId) {
+    // An archive's \title wins over the fallback name; only override it when the
+    // caller explicitly supplied a project name.
+    const preserveName = Boolean(params.projectName)
     const projectName = ProjectDetailsHandler.fixProjectName(
       params.projectName || DEFAULT_PROJECT_NAME
     )
@@ -247,13 +263,15 @@ const OpenInOverleafManager = {
       project = await OpenInOverleafManager._createFromZipUrl(
         params.zipUri,
         ownerId,
-        projectName
+        projectName,
+        preserveName
       )
     } else if (params.snipUris && params.snipUris.length) {
       project = await OpenInOverleafManager._createFromUrls(
         params.snipUris,
         ownerId,
-        projectName
+        projectName,
+        preserveName
       )
     } else if (params.snippet != null) {
       project = await ProjectCreationHandler.promises.createProjectFromSnippet(
@@ -269,15 +287,15 @@ const OpenInOverleafManager = {
     return project
   },
 
-  async _createFromZipUrl(zipUri, ownerId, projectName) {
+  async _createFromZipUrl(zipUri, ownerId, projectName, preserveName) {
     const buffer = await fetchUrlToBuffer(zipUri)
     if (!looksLikeZip(buffer)) {
       throw new OpenInOverleafError('zip_uri did not resolve to a zip archive')
     }
-    return await importZipBuffer(buffer, ownerId, projectName)
+    return await importZipBuffer(buffer, ownerId, projectName, preserveName)
   },
 
-  async _createFromUrls(snipUris, ownerId, projectName) {
+  async _createFromUrls(snipUris, ownerId, projectName, preserveName) {
     if (snipUris.length > MAX_SNIP_URIS) {
       throw new OpenInOverleafError(
         `too many snip_uri entries (maximum ${MAX_SNIP_URIS})`
@@ -301,7 +319,7 @@ const OpenInOverleafManager = {
     if (files.length === 1) {
       const [file] = files
       if (file.isZip) {
-        return await importZipBuffer(file.buffer, ownerId, projectName)
+        return await importZipBuffer(file.buffer, ownerId, projectName, preserveName)
       }
       if (!file.explicit) {
         // A single .tex file → straight snippet project as main.tex.
@@ -312,7 +330,7 @@ const OpenInOverleafManager = {
         )
       }
       // snip_name given: import under that name so main_document can select it.
-      return await importFilesAsZip(files, ownerId, projectName)
+      return await importFilesAsZip(files, ownerId, projectName, preserveName)
     }
 
     if (files.some(file => file.isZip)) {
@@ -320,7 +338,7 @@ const OpenInOverleafManager = {
         'a zip archive must be the only snip_uri; use zip_uri for projects'
       )
     }
-    return await importFilesAsZip(files, ownerId, projectName)
+    return await importFilesAsZip(files, ownerId, projectName, preserveName)
   },
 
   async _applyOptions(project, params) {

--- a/services/web/modules/open-in-overleaf/app/src/OpenInOverleafManager.mjs
+++ b/services/web/modules/open-in-overleaf/app/src/OpenInOverleafManager.mjs
@@ -1,0 +1,332 @@
+import fs from 'node:fs'
+import Path from 'node:path'
+import crypto from 'node:crypto'
+import { pipeline } from 'node:stream/promises'
+import archiver from 'archiver'
+import settings from '@overleaf/settings'
+import logger from '@overleaf/logger'
+import urlValidator from 'valid-url'
+import { fetchStream, RequestFailedError } from '@overleaf/fetch-utils'
+import UrlHelper from '../../../../app/src/Features/Helpers/UrlHelper.mjs'
+import ProjectCreationHandler from '../../../../app/src/Features/Project/ProjectCreationHandler.mjs'
+import ProjectUploadManager from '../../../../app/src/Features/Uploads/ProjectUploadManager.mjs'
+import ProjectOptionsHandler from '../../../../app/src/Features/Project/ProjectOptionsHandler.mjs'
+import ProjectRootDocManager from '../../../../app/src/Features/Project/ProjectRootDocManager.mjs'
+import ProjectDetailsHandler from '../../../../app/src/Features/Project/ProjectDetailsHandler.mjs'
+import ProjectHelper from '../../../../app/src/Features/Project/ProjectHelper.mjs'
+
+// "Open in Overleaf" / Prefilled-Project API (POST|GET /docs), documented on the
+// official /devs page. External sites load LaTeX content into a new project by
+// posting a snippet, a file/zip URL, or a base64 data URL. The SaaS module is
+// not shipped in open-source, so this reproduces the same contract on top of the
+// existing project-creation infrastructure.
+//
+// Security: user-supplied snip_uri / zip_uri are fetched THROUGH the
+// linked-url-proxy (UrlHelper.wrapUrlWithProxy) — the same SSRF-guarded path
+// LinkedFiles/UrlAgent uses (ipaddr.js unicast-only + blockedNetworks + DNS
+// re-validation). data: URLs are decoded in-process (no network fetch).
+
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]) // "PK\x03\x04"
+const DEFAULT_PROJECT_NAME = 'Open in Overleaf project'
+// Generous: the proxy already applies its own 30s timeout per hop, and a
+// redirect chain plus a slow origin must not be cut off by us first.
+const FETCH_TIMEOUT_MS = 60 * 1000
+
+class OpenInOverleafError extends Error {}
+
+// "Decoration" + "Encoding" features from the /devs docs: normalise Windows
+// newlines to unix, and — if a bare snippet has no \documentclass — wrap it in a
+// standard compilable document so the imported project builds out of the box.
+const DOCUMENT_WRAPPER_HEAD = [
+  '\\documentclass[12pt]{article}',
+  '\\usepackage[english]{babel}',
+  '\\usepackage{amsmath}',
+  '\\usepackage{tikz}',
+  '\\begin{document}',
+]
+const DOCUMENT_WRAPPER_TAIL = ['\\end{document}']
+
+function prepareSnippet(content) {
+  const normalised = content.replace(/\r\n/g, '\n')
+  if (/\\documentclass/.test(normalised)) {
+    return normalised
+  }
+  return [...DOCUMENT_WRAPPER_HEAD, normalised, ...DOCUMENT_WRAPPER_TAIL].join(
+    '\n'
+  )
+}
+
+function dumpPath(suffix = '') {
+  return `${settings.path.dumpFolder}/${crypto.randomUUID()}_open-in-overleaf${suffix}`
+}
+
+function looksLikeZip(buffer) {
+  return buffer.subarray(0, 4).equals(ZIP_MAGIC)
+}
+
+function tooLarge(what, maxBytes) {
+  return new OpenInOverleafError(
+    `${what} is larger than the ${Math.round(maxBytes / 1024 / 1024)} MB limit`
+  )
+}
+
+// File name for an uploaded snippet: snip_name[] if given, otherwise the last
+// path segment of the URL, otherwise a numbered default. Directory parts are
+// dropped so a name can never escape the project root inside the zip.
+function safeFileName(name, url, index) {
+  const candidates = [name]
+  if (/^https?:\/\//i.test(url)) {
+    try {
+      candidates.push(decodeURIComponent(new URL(url).pathname))
+    } catch (e) {
+      // unparsable url, fall through to the default name
+    }
+  }
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue
+    const base = Path.posix.basename(candidate.replace(/\\/g, '/')).trim()
+    if (base && base !== '.' && base !== '..') return base
+  }
+  return `snippet-${index + 1}.tex`
+}
+
+// Decode a `data:[<mime>][;base64],<payload>` URL into a Buffer.
+function decodeDataUrl(url, maxBytes) {
+  const match = /^data:([^,]*?),(.*)$/s.exec(url)
+  if (!match) {
+    throw new OpenInOverleafError('invalid data url')
+  }
+  const [, meta, rawPayload] = match
+  let payload
+  try {
+    payload = decodeURIComponent(rawPayload)
+  } catch (e) {
+    payload = rawPayload
+  }
+  let buffer
+  if (/;base64/i.test(meta)) {
+    // A '+' in a query string arrives as a space unless the caller encoded it.
+    const b64 = payload.replace(/ /g, '+').replace(/\s/g, '')
+    // Node's decoder silently skips invalid characters, so validate the
+    // alphabet ourselves: otherwise garbage becomes a project.
+    if (!/^[A-Za-z0-9+/]*={0,2}$/.test(b64) || b64.length % 4 === 1) {
+      throw new OpenInOverleafError('invalid base64 data url')
+    }
+    buffer = Buffer.from(b64, 'base64')
+  } else {
+    buffer = Buffer.from(payload, 'utf8')
+  }
+  if (buffer.length > maxBytes) {
+    throw tooLarge('data url', maxBytes)
+  }
+  return buffer
+}
+
+async function readStreamToBuffer(stream, maxBytes, what) {
+  const chunks = []
+  let size = 0
+  for await (const chunk of stream) {
+    size += chunk.length
+    if (size > maxBytes) {
+      stream.destroy()
+      throw tooLarge(what, maxBytes)
+    }
+    chunks.push(chunk)
+  }
+  return Buffer.concat(chunks)
+}
+
+// Fetch a snippet/zip URL into a Buffer. http(s) go through the SSRF proxy;
+// data: URLs are decoded locally.
+async function fetchUrlToBuffer(rawUrl) {
+  const maxBytes = settings.maxUploadSize
+  if (/^data:/i.test(rawUrl)) {
+    return decodeDataUrl(rawUrl, maxBytes)
+  }
+  const url = UrlHelper.prependHttpIfNeeded(rawUrl.trim())
+  if (!urlValidator.isWebUri(url)) {
+    throw new OpenInOverleafError(`invalid url: ${rawUrl}`)
+  }
+  if (!settings.apis.linkedUrlProxy?.url) {
+    throw new OpenInOverleafError(
+      'downloading from external URLs is not enabled on this server'
+    )
+  }
+  const proxied = UrlHelper.wrapUrlWithProxy(url)
+  let stream
+  try {
+    stream = await fetchStream(proxied, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+  } catch (err) {
+    if (err instanceof RequestFailedError) {
+      // The proxy answers 4xx for blocked, unreachable or oversized targets.
+      throw new OpenInOverleafError(
+        `could not download ${url} (HTTP ${err.response.status})`
+      )
+    }
+    if (err.name === 'AbortError' || err.name === 'TimeoutError') {
+      throw new OpenInOverleafError(`timed out downloading ${url}`)
+    }
+    throw err
+  }
+  return await readStreamToBuffer(stream, maxBytes, url)
+}
+
+async function importZipBuffer(buffer, ownerId, projectName) {
+  const path = await writeBufferToDump(buffer, '.zip')
+  try {
+    return await ProjectUploadManager.promises.createProjectFromZipArchive(
+      ownerId,
+      projectName,
+      path
+    )
+  } finally {
+    fs.promises.unlink(path).catch(() => {})
+  }
+}
+
+async function writeBufferToDump(buffer, suffix) {
+  const path = dumpPath(suffix)
+  await fs.promises.writeFile(path, buffer)
+  return path
+}
+
+// Zip a set of in-memory files ({ name, buffer }) so multi-file submissions can
+// reuse the standard zip-import path.
+async function buildZipFromFiles(files) {
+  const path = dumpPath('.zip')
+  const output = fs.createWriteStream(path)
+  const archive = archiver('zip')
+  const done = new Promise((resolve, reject) => {
+    output.on('close', resolve)
+    archive.on('error', reject)
+  })
+  archive.pipe(output)
+  for (const file of files) {
+    archive.append(file.buffer, { name: file.name })
+  }
+  await archive.finalize()
+  await done
+  return path
+}
+
+const OpenInOverleafManager = {
+  // params: {
+  //   snippet?, snipUris?: [{ url, name }], zipUri?,
+  //   engine?, mainDocument?, projectName?
+  // }
+  async createProject(params, ownerId) {
+    const projectName = ProjectDetailsHandler.fixProjectName(
+      params.projectName || DEFAULT_PROJECT_NAME
+    )
+
+    let project
+    if (params.zipUri) {
+      project = await OpenInOverleafManager._createFromZipUrl(
+        params.zipUri,
+        ownerId,
+        projectName
+      )
+    } else if (params.snipUris && params.snipUris.length) {
+      project = await OpenInOverleafManager._createFromUrls(
+        params.snipUris,
+        ownerId,
+        projectName
+      )
+    } else if (params.snippet != null) {
+      project = await ProjectCreationHandler.promises.createProjectFromSnippet(
+        ownerId,
+        projectName,
+        prepareSnippet(params.snippet).split('\n')
+      )
+    } else {
+      throw new OpenInOverleafError('no snippet, snip_uri or zip_uri provided')
+    }
+
+    await OpenInOverleafManager._applyOptions(project, params)
+    return project
+  },
+
+  async _createFromZipUrl(zipUri, ownerId, projectName) {
+    const buffer = await fetchUrlToBuffer(zipUri)
+    if (!looksLikeZip(buffer)) {
+      throw new OpenInOverleafError('zip_uri did not resolve to a zip archive')
+    }
+    return await importZipBuffer(buffer, ownerId, projectName)
+  },
+
+  async _createFromUrls(snipUris, ownerId, projectName) {
+    const files = []
+    for (const [index, { url, name }] of snipUris.entries()) {
+      const buffer = await fetchUrlToBuffer(url)
+      files.push({
+        buffer,
+        name: safeFileName(name, url, index),
+        isZip: looksLikeZip(buffer),
+      })
+    }
+
+    if (files.length === 1) {
+      const [file] = files
+      if (file.isZip) {
+        return await importZipBuffer(file.buffer, ownerId, projectName)
+      }
+      // A single .tex file → straight snippet project (keeps the nice main.tex).
+      return await ProjectCreationHandler.promises.createProjectFromSnippet(
+        ownerId,
+        projectName,
+        prepareSnippet(file.buffer.toString('utf8')).split('\n')
+      )
+    }
+
+    if (files.some(file => file.isZip)) {
+      throw new OpenInOverleafError(
+        'a zip archive must be the only snip_uri; use zip_uri for projects'
+      )
+    }
+
+    // Multiple files → zip them up and import as one project.
+    const zipPath = await buildZipFromFiles(files)
+    try {
+      return await ProjectUploadManager.promises.createProjectFromZipArchive(
+        ownerId,
+        projectName,
+        zipPath
+      )
+    } finally {
+      fs.promises.unlink(zipPath).catch(() => {})
+    }
+  },
+
+  async _applyOptions(project, params) {
+    if (params.engine) {
+      const compiler =
+        ProjectHelper.compilerFromV1Engine(params.engine) || params.engine
+      try {
+        await ProjectOptionsHandler.promises.setCompiler(project._id, compiler)
+      } catch (err) {
+        logger.warn(
+          { err, projectId: project._id, engine: params.engine },
+          'open-in-overleaf: failed to set compiler'
+        )
+      }
+    }
+    if (params.mainDocument) {
+      try {
+        await ProjectRootDocManager.promises.setRootDocFromName(
+          project._id,
+          params.mainDocument
+        )
+      } catch (err) {
+        logger.warn(
+          { err, projectId: project._id, mainDocument: params.mainDocument },
+          'open-in-overleaf: failed to set main document'
+        )
+      }
+    }
+  },
+}
+
+export default OpenInOverleafManager
+export { OpenInOverleafError }

--- a/services/web/modules/open-in-overleaf/app/src/OpenInOverleafRouter.mjs
+++ b/services/web/modules/open-in-overleaf/app/src/OpenInOverleafRouter.mjs
@@ -1,0 +1,40 @@
+import logger from '@overleaf/logger'
+import AuthenticationController from '../../../../app/src/Features/Authentication/AuthenticationController.mjs'
+import OpenInOverleafController from './OpenInOverleafController.mjs'
+
+// "Open in Overleaf" / Prefilled-Project API (documented at /devs). Reproduces
+// the SaaS-only `/docs` endpoint on Ayakaleaf Pro.
+//
+//   GET  /docs   — link form (`/docs?snip_uri=…` / `?encoded_snip=…`). No Origin
+//                  header on a top-level navigation, so it is never blocked by
+//                  blockCrossOriginRequests, and requireLogin's postLoginRedirect
+//                  carries the query params through a login round-trip.
+//   POST /docs   — form/AJAX form. CSRF is disabled here (external submitters
+//                  have no token). Cross-origin POSTs still need the submitting
+//                  site's origin in Settings.allowedOrigins; same-origin (the
+//                  /devs examples) always works.
+//   GET  /devs   — public "Overleaf API" documentation page.
+export default {
+  apply(webRouter) {
+    logger.debug({}, 'Init open-in-overleaf router')
+
+    // External sites post here without a CSRF token; exempt the route (the
+    // csurf middleware still attaches req.csrfToken() for rendered forms).
+    if (webRouter.csrf) {
+      webRouter.csrf.disableDefaultCsrfProtection('/docs', 'POST')
+    }
+
+    webRouter.get(
+      '/docs',
+      AuthenticationController.requireLogin(),
+      OpenInOverleafController.openInOverleaf
+    )
+    webRouter.post(
+      '/docs',
+      AuthenticationController.requireLogin(),
+      OpenInOverleafController.openInOverleaf
+    )
+
+    webRouter.get('/devs', OpenInOverleafController.devsPage)
+  },
+}

--- a/services/web/modules/open-in-overleaf/app/src/OpenInOverleafRouter.mjs
+++ b/services/web/modules/open-in-overleaf/app/src/OpenInOverleafRouter.mjs
@@ -42,11 +42,14 @@ export default {
     )
     webRouter.post(
       '/docs',
+      // Rate-limit first (by user id when logged in, otherwise by IP): a
+      // signed-out submitter must not be able to park unlimited bodies in
+      // redis via stashForLogin, which runs — and redirects — before requireLogin.
+      RateLimiterMiddleware.rateLimit(openInOverleafRateLimiter),
       // Must run before requireLogin: it parks the POST body for signed-out
       // (or cross-site) submitters, which a login redirect would drop.
       OpenInOverleafController.stashForLogin,
       AuthenticationController.requireLogin(),
-      RateLimiterMiddleware.rateLimit(openInOverleafRateLimiter),
       OpenInOverleafController.openInOverleaf
     )
 

--- a/services/web/modules/open-in-overleaf/app/src/OpenInOverleafRouter.mjs
+++ b/services/web/modules/open-in-overleaf/app/src/OpenInOverleafRouter.mjs
@@ -1,5 +1,7 @@
 import logger from '@overleaf/logger'
 import AuthenticationController from '../../../../app/src/Features/Authentication/AuthenticationController.mjs'
+import RateLimiterMiddleware from '../../../../app/src/Features/Security/RateLimiterMiddleware.mjs'
+import { RateLimiter } from '../../../../app/src/infrastructure/RateLimiter.mjs'
 import OpenInOverleafController from './OpenInOverleafController.mjs'
 
 // "Open in Overleaf" / Prefilled-Project API (documented at /devs). Reproduces
@@ -14,6 +16,14 @@ import OpenInOverleafController from './OpenInOverleafController.mjs'
 //                  site's origin in Settings.allowedOrigins; same-origin (the
 //                  /devs examples) always works.
 //   GET  /devs   — public "Overleaf API" documentation page.
+
+// Same budget as /project/new and /project/new/upload: every /docs hit is a
+// project creation, usually with a remote download and an archive extraction.
+const openInOverleafRateLimiter = new RateLimiter('open-in-overleaf', {
+  points: 20,
+  duration: 60,
+})
+
 export default {
   apply(webRouter) {
     logger.debug({}, 'Init open-in-overleaf router')
@@ -27,11 +37,16 @@ export default {
     webRouter.get(
       '/docs',
       AuthenticationController.requireLogin(),
+      RateLimiterMiddleware.rateLimit(openInOverleafRateLimiter),
       OpenInOverleafController.openInOverleaf
     )
     webRouter.post(
       '/docs',
+      // Must run before requireLogin: it parks the POST body for signed-out
+      // (or cross-site) submitters, which a login redirect would drop.
+      OpenInOverleafController.stashForLogin,
       AuthenticationController.requireLogin(),
+      RateLimiterMiddleware.rateLimit(openInOverleafRateLimiter),
       OpenInOverleafController.openInOverleaf
     )
 

--- a/services/web/modules/open-in-overleaf/app/views/devs.pug
+++ b/services/web/modules/open-in-overleaf/app/views/devs.pug
@@ -1,0 +1,283 @@
+extends ../../../../app/views/layout-website-redesign
+
+block vars
+	- isWebsiteRedesign = true
+
+block entrypointVar
+	- entrypoint = 'modules/open-in-overleaf/pages/devs/devs'
+
+block content
+	-
+		// The public base URL of this instance, used verbatim in the examples so
+		// people can copy/paste working "Open in Overleaf" snippets.
+		var base = olBaseUrl
+		var docsUrl = base + '/docs'
+		var helloTex = '\\documentclass[12pt]{article}\n\\usepackage{amsmath}\n\\usepackage{amsfonts}\n\\begin{document}\n\n$\\mathfrak{H}$ello world!\n\\end{document}\n\n'
+		var helloB64 = Buffer.from(helloTex).toString('base64')
+		var phpTex = '\\documentclass{article}\n\\begin{document}\nHello $i$ \\& $j$.\n\\end{document}\n'
+		var rawTex = '\\documentclass[12pt,letterpaper]{article}\n\\usepackage[T1]{fontenc}\n\\usepackage{amsmath}\n\\begin{document}\n\\noindent\nBla bla bla bla :\n\\begin{align*}\nA &= B + C - D \\\\ \\\\\n%phantom\n&\\phantom{= B + C \\;}\n%phantom\n+ D - E \\\\ \\\\\n&= F + G - H.\n\\end{align*}\n\\end{document}\n'
+
+	style.
+		.oio-devs { max-width: 820px; margin: 0 auto; }
+		.oio-devs h1 { margin-bottom: var(--spacing-08, 24px); }
+		.oio-devs h2 { margin-top: var(--spacing-11, 48px); }
+		.oio-devs h3 { margin-top: var(--spacing-09, 32px); }
+		.oio-devs pre { background: var(--bg-light-secondary, #f4f5f6); border: 1px solid var(--neutral-20, #e7e9ee); border-radius: 8px; padding: 16px; overflow-x: auto; font-size: 13px; line-height: 1.5; }
+		.oio-devs .oio-example { background: var(--bg-light-secondary, #f4f5f6); border: 1px solid var(--neutral-20, #e7e9ee); border-radius: 8px; padding: 20px; margin: 16px 0; }
+		.oio-devs .oio-example .form-control { margin-bottom: 12px; }
+		.oio-devs .oio-codebox { background: var(--bg-light-secondary, #f4f5f6); border: 1px solid var(--neutral-20, #e7e9ee); border-radius: 8px; padding: 12px 16px 16px; margin: 16px 0; overflow-x: auto; }
+		.oio-devs .oio-codebox dt { font-weight: 600; font-size: 13px; color: var(--neutral-70, #677283); margin-bottom: 8px; }
+		.oio-devs .oio-codebox dd { margin: 0; }
+		.oio-devs .oio-codebox pre { margin: 0; padding: 0; background: none; border: 0; }
+		.oio-devs .oio-codebox code { display: block; white-space: pre; font-size: 13px; line-height: 1.5; }
+		.oio-devs .oio-codebox .hl-command { color: #0550ae; }
+		.oio-devs .oio-codebox .hl-brace { color: #953800; }
+		.oio-devs .oio-codebox .hl-comment { color: var(--neutral-70, #677283); font-style: italic; }
+
+	main#main-content.content.content-alt(role='main')
+		.container-xxl
+			.oio-devs
+				h1 Overleaf API
+				p.lead Do you have your own LaTeX site? Would you like to add “Open in Overleaf” functionality to help it stand out? If so, you’re at the right place!
+				h2 One-click to open in Overleaf…
+				p We’ve developed the tools you need to load LaTeX code and files from your website or blog directly into Overleaf.
+				p See it in action: every example in the sections below opens a real project on this server.
+				p To add similar functionality to your site, take a look at the sections below.
+
+				h2 Overview
+				p.
+					You can load a code snippet into Overleaf by passing it (or its URI) to
+					<code>#{docsUrl}</code> using a form or a link.
+				p The most basic approach is to use a link:
+				pre= docsUrl + '?snip_uri=http://pathtoyourfile.tex'
+				p You may also link to a project instead of a single LaTeX snippet by passing the location of a zip file for the <code>zip_uri</code> parameter. Here are some links in action:
+				p
+					a.btn.btn-primary.me-2(href=`${docsUrl}?snip_uri=${encodeURIComponent('data:application/x-tex;base64,' + helloB64)}`) A LaTeX code snippet
+					a.btn.btn-primary(href=`${docsUrl}?zip_uri=${encodeURIComponent('data:application/zip;base64,' + olDemoZipB64)}`) A zipped project
+				p Some more advanced methods of embedding and opening LaTeX content are listed below in the implementations section. There are also a number of customisable features that can tailor the “Open in Overleaf” functionality to your needs. These can be found in the features section below.
+
+				h2 Implementations
+
+				h3 Post a Snippet by URI (URL)
+				p You can post the URI of a file, and Overleaf will download the file and import it as the main file of the project. The file must be accessible from this server. The file will be fetched using either HTTP or HTTPS, depending on the URI that you give it; other protocols are not supported. Files should be LaTeX files or zip format.
+				p Here we pass the full path to this file for the <code>snip_uri</code> parameter:
+				.oio-example
+					form(action=docsUrl method='post' target='_blank')
+						input.form-control(type='text' name='snip_uri' value='https://your-site.example/examples/helloworld.tex')
+						button.btn.btn-primary(type='submit') Open in Overleaf
+				p This form can be implemented with the following code:
+				pre.
+					&lt;form action="#{docsUrl}" method="post" target="_blank"&gt;
+					  &lt;input type="text" name="snip_uri"
+					         value="https://your-site.example/examples/helloworld.tex"&gt;&lt;br&gt;
+					  &lt;input type="submit" value="Open in Overleaf"&gt;
+					&lt;/form&gt;
+				p Alternatively you can just use a link, as described in the Overview section above. We recommend that you use <code>encodeURIComponent</code> (or an equivalent method server-side) to escape each parameter, but this is not absolutely necessary.
+				p You can also upload multiple files using <code>snip_uri[]</code> array parameters like this:
+				pre= docsUrl + '?snip_uri[]=http://.../a.tex&snip_uri[]=http://.../b.tex'
+				p And there’s a <code>snip_name[]</code> parameter that you can use to override the name of each uploaded file:
+				pre.
+					#{docsUrl}?snip_uri[]=http://.../a.tex&amp;
+					  snip_uri[]=http://.../b.tex&amp;
+					  snip_name[]=file1.tex&amp;
+					  snip_name[]=file2.tex
+
+				h3 Base64 Data URL
+				p It is possible to use a data URL with a base64 string as the <code>snip_uri</code> value:
+				pre data:[mime_type];base64,[your_base64_encoded_file]
+				p For example, this is the same <code>helloworld.tex</code> file but encoded as base64:
+				.oio-example
+					form(action=docsUrl method='post' target='_blank')
+						input.form-control(type='text' name='snip_uri' value=`data:application/x-tex;base64,${helloB64}`)
+						button.btn.btn-primary(type='submit') Open in Overleaf
+				p This form can be implemented with the following code:
+				pre.
+					&lt;form action="#{docsUrl}" method="post" target="_blank"&gt;
+					  &lt;input type="text" name="snip_uri"
+					         value="data:application/x-tex;base64,#{helloB64}"&gt;&lt;br&gt;
+					  &lt;input type="submit" value="Open in Overleaf"&gt;
+					&lt;/form&gt;
+				p Base64 strings can also represent compressed zip files containing multiple files. For instance, here’s a simple case with two <code>.tex</code> files and a single <code>.bib</code> file:
+				.oio-example
+					form(action=docsUrl method='post' target='_blank')
+						input.form-control(type='text' name='zip_uri' value=`data:application/zip;base64,${olDemoZipB64}`)
+						button.btn.btn-primary(type='submit') Open in Overleaf
+				p This form can be implemented with the following code:
+				pre.
+					&lt;form action="#{docsUrl}" method="post" target="_blank"&gt;
+					  &lt;input type="text" name="zip_uri"
+					         value="data:application/zip;base64,#{olDemoZipB64}"&gt;&lt;br&gt;
+					  &lt;input type="submit" value="Open in Overleaf"&gt;
+					&lt;/form&gt;
+
+				h3 URL-encoded snippet
+				p URL encoding is useful if you submit using a hidden input field, as in this example. This avoids problems with newlines in the TeX source. This example posts the result of the PHP5 code:
+				pre.
+					urlencode("\\documentclass{article}\n\\begin{document}\nHello \$i\$ \\& \$j\$.\n\\end{document}\n");
+				p in the <code>encoded_snip</code> parameter. If using JavaScript, the <code>encodeURIComponent</code> function should be used (not the <code>escape</code> function, which has problems with internationalisation).
+				.oio-example
+					form(action=docsUrl method='post' target='_blank')
+						input(type='hidden' name='encoded_snip' value=encodeURIComponent(phpTex))
+						button.btn.btn-primary(type='submit') Open in Overleaf
+
+				h3 Raw snippet
+				p If you submit from the server side or with AJAX you can use the <code>snip</code> parameter, which assumes no encoding. Another use case is submission from a textarea (which could be hidden using CSS); in this case you must escape HTML entities in the HTML source.
+				.oio-example
+					form(action=docsUrl method='post' target='_blank')
+						textarea.form-control(name='snip' rows='8')= rawTex
+						button.btn.btn-primary(type='submit') Open in Overleaf
+				p This form can be implemented with the following code:
+				pre.
+					&lt;form action="#{docsUrl}" method="post" target="_blank"&gt;
+					  &lt;textarea rows="8" cols="60" name="snip"&gt;
+					  \documentclass[12pt,letterpaper]{article}
+					  \usepackage[T1]{fontenc}
+					  \usepackage{amsmath}
+					  \begin{document}
+					  \noindent
+					  Bla bla bla bla :
+					  \begin{align*}
+					  A &amp;= B + C - D \\ \\
+					  %phantom
+					  &amp;\phantom{= B + C \;}
+					  %phantom
+					  + D - E \\ \\
+					  &amp;= F + G - H.
+					  \end{align*}
+					  \end{document}
+					  &lt;/textarea&gt;
+					  &lt;input type="submit" value="Open in Overleaf"&gt;
+					&lt;/form&gt;
+
+				h3 Post from Formatted Code Box
+				p This example shows how to extract the unformatted code from a CSS-styled code box and submit it to Overleaf. The key components are:
+				ol
+					li The JavaScript that defines the <code>openInOverleaf()</code> function.
+					li The <code>form</code> with id <code>ol_form</code>, which is used to POST the source as a URL-encoded snippet. Note that in this case you only need one form on the page, even if you have multiple code boxes.
+					li The link in the code box that actually calls <code>openInOverleaf()</code>.
+				h4 Examples
+				dl.codebox.oio-codebox
+					dt Code: <a href="#" onclick="openInOverleaf(this); return false;">Open in Overleaf</a>
+					dd
+						pre
+							code.tex.
+								\renewcommand{\arraystretch}{2}
+								\[
+								g :=\left(
+								\begin{array}{c|c}
+								\mathbf{2^D} &amp; \textbf{1} \\ \hline
+								\textbf{1} &amp; \begin{array}{cc}
+								\boldsymbol{1^\alpha} &amp; \textbf{0} \\
+								\textbf{0} &amp; \boldsymbol{1^\beta}
+								\end{array} \\
+								\end{array}
+								\right)
+								\]
+				dl.codebox.oio-codebox
+					dt Code: <a href="#" onclick="openInOverleaf(this); return false;">Open in Overleaf</a>
+					dd
+						pre
+							code.tex.
+								\documentclass{article}
+								\usepackage{tikz}
+								\usetikzlibrary{arrows}
+								\begin{document}
+								\begin{tikzpicture}[-&gt;,&gt;=stealth',shorten &gt;=1pt,auto,node distance=3cm,
+								  thick,main node/.style={circle,fill=blue!20,draw,font=\sffamily\Large\bfseries}]
+								
+								  \node[main node] (1) {1};
+								  \node[main node] (2) [below left of=1] {2};
+								  \node[main node] (3) [below right of=2] {3};
+								  \node[main node] (4) [below right of=1] {4};
+								
+								  \path[every node/.style={font=\sffamily\small}]
+								    (1) edge node [left] {0.6} (4)
+								        edge [bend right] node[left] {0.3} (2)
+								        edge [loop above] node {0.1} (1)
+								    (2) edge node [right] {0.4} (1)
+								        edge node {0.3} (4)
+								        edge [loop left] node {0.4} (2)
+								        edge [bend right] node[left] {0.1} (3)
+								    (3) edge node [right] {0.8} (2)
+								        edge [bend right] node[right] {0.2} (4)
+								    (4) edge node [left] {0.2} (3)
+								        edge [loop right] node {0.6} (4)
+								        edge [bend right] node[right] {0.2} (1);
+								\end{tikzpicture}
+								\end{document}
+				form#ol_form(action=docsUrl method='post' target='_blank' style='display:none')
+					input#ol_encoded_snip(type='hidden' name='encoded_snip')
+
+				h4 Implementation
+				p The HTML required to add the examples above is:
+				pre.
+					&lt;form id="ol_form" action="#{docsUrl}" method="post" target="_blank"&gt;
+					  &lt;input id="ol_encoded_snip" type="hidden" name="encoded_snip"&gt;
+					&lt;/form&gt;
+					&lt;dl class="codebox"&gt;
+					  &lt;dt&gt;Code: &lt;a href="#" onclick="openInOverleaf(this); return false;"&gt;Open in Overleaf&lt;/a&gt;&lt;/dt&gt;
+					  &lt;dd&gt;
+					    &lt;pre&gt;
+					      &lt;code class="tex"&gt;
+					        \documentclass{article}
+					        ...
+					      &lt;/code&gt;
+					    &lt;/pre&gt;
+					  &lt;/dd&gt;
+					&lt;/dl&gt;
+				p The JavaScript code for the openInOverleaf method, which should be included in a <code>script</code> tag is:
+				pre.
+					function openInOverleaf(a) {
+					  /*
+					  * Get the unformatted code from the formatted code box.
+					  *
+					  * Using the browser's selection isn't ideal, because it clobbers whatever
+					  * the user may have had in their clipboard.
+					  * It's almost possible to use innerText, but that does not work on FF.
+					  * FF supports textContent, but that discards the newlines, which are
+					  * represented by BR tags in the formatted code. So, we have to walk the DOM.
+					  */
+					  function unformat(e) {
+					    var ret = "";
+					    if (e.nodeType === 1) { // element node
+					      if (e.tagName === "BR") {
+					        return "\n";
+					      } else {
+					        for (e = e.firstChild; e; e = e.nextSibling) {
+					            ret += unformat(e);
+					        }
+					        return ret;
+					      }
+					    } else if (e.nodeType === 3 || e.nodeType === 4) { // text node
+					        return e.nodeValue;
+					    }
+					  }
+					  var code = a.parentNode.parentNode.getElementsByTagName('CODE')[0];
+					  document.getElementById('ol_encoded_snip').value =
+					    encodeURIComponent(unformat(code));
+					  document.getElementById('ol_form').submit();
+					}
+				p The syntax highlighting in the code boxes is added with a few <code>span</code> elements; you can generate yours with a library such as highlight.js, or add them manually if you prefer.
+
+				h2 Features
+				p The features below are included to aid usability of the “Open in Overleaf” implementations, and may be customised to suit your preferences.
+
+				h3 Decoration
+				p The code must be wrapped in a valid document in order to compile. If the code snippet does not have a <code>\documentclass</code> tag, it is wrapped in a standard document when it is imported:
+				pre.
+					\documentclass[12pt]{article}
+					\usepackage[english]{babel}
+					\usepackage{amsmath}
+					\usepackage{tikz}
+					\begin{document}
+					SNIPPET GOES HERE
+					\end{document}
+
+				h3 Encoding
+				p The submitted snippet should be encoded using UTF-8. Windows newlines are converted to unix newlines.
+
+				h3 TeX Engine
+				p By default, Overleaf tries to detect which TeX engine to use, and usually chooses <code>pdflatex</code>. If you would like to set the engine explicitly for your new project, you can pass an <code>engine</code> parameter with one of the following values: <code>latex_dvipdf</code>, <code>pdflatex</code>, <code>xelatex</code> or <code>lualatex</code>.
+
+				h3 Main Document
+				p By default, Overleaf tries to detect which document to use as the main <code>.tex</code> file, based on whether it contains a <code>\documentclass</code>. If you would like to override this behaviour, you can pass a <code>main_document</code> parameter with the name of the file. When supplying an array of snippets, you must also pass an array of filenames for this to work reliably.

--- a/services/web/modules/open-in-overleaf/app/views/error.pug
+++ b/services/web/modules/open-in-overleaf/app/views/error.pug
@@ -1,0 +1,14 @@
+extends ../../../../app/views/layout-website-redesign
+
+block vars
+	- isWebsiteRedesign = true
+
+block content
+	main#main-content.content.content-alt(role='main')
+		.container
+			.row
+				.col-md-8.offset-md-2.text-center
+					h1 Open in Overleaf
+					p.lead= message
+					p
+						a.btn.btn-primary(href='/devs') View the Overleaf API docs

--- a/services/web/modules/open-in-overleaf/frontend/js/pages/devs/devs.js
+++ b/services/web/modules/open-in-overleaf/frontend/js/pages/devs/devs.js
@@ -1,0 +1,55 @@
+// /devs "Overleaf API" documentation page.
+//
+// openInOverleaf() is the exact snippet published on the page (and on
+// www.overleaf.com/devs), so what visitors copy is what runs here: it walks the
+// DOM of the code box (<br> -> newline, which innerText/textContent get wrong
+// across browsers), URL-encodes the source into #ol_encoded_snip and submits
+// the single shared #ol_form to POST /docs.
+import '../../../../../../frontend/js/marketing'
+
+function openInOverleaf(a) {
+  function unformat(e) {
+    var ret = ''
+    if (e.nodeType === 1) {
+      // element node
+      if (e.tagName === 'BR') {
+        return '\n'
+      } else {
+        for (e = e.firstChild; e; e = e.nextSibling) {
+          ret += unformat(e)
+        }
+        return ret
+      }
+    } else if (e.nodeType === 3 || e.nodeType === 4) {
+      // text node
+      return e.nodeValue
+    }
+  }
+  var code = a.parentNode.parentNode.getElementsByTagName('CODE')[0]
+  document.getElementById('ol_encoded_snip').value = encodeURIComponent(
+    unformat(code)
+  )
+  document.getElementById('ol_form').submit()
+}
+
+// Light-weight LaTeX highlighting for the code boxes (the official page uses
+// highlight.js). Wrapping tokens in spans is safe for openInOverleaf(): unformat()
+// walks the DOM and concatenates the text nodes.
+function escapeHtml(text) {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function highlightLatex(code) {
+  return escapeHtml(code)
+    .replace(/(%[^\n]*)/g, '<span class="hl-comment">$1</span>')
+    .replace(/(\\[A-Za-z@]+\*?)/g, '<span class="hl-command">$1</span>')
+    .replace(/([{}[\]])/g, '<span class="hl-brace">$1</span>')
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  for (const code of document.querySelectorAll('.codebox code')) {
+    code.innerHTML = highlightLatex(code.textContent)
+  }
+})
+
+window.openInOverleaf = openInOverleaf

--- a/services/web/modules/open-in-overleaf/index.mjs
+++ b/services/web/modules/open-in-overleaf/index.mjs
@@ -1,0 +1,13 @@
+import OpenInOverleafRouter from './app/src/OpenInOverleafRouter.mjs'
+
+// Open in Overleaf module for Ayakaleaf Pro.
+//
+// The SaaS "Open in Overleaf" / Prefilled-Project API (the `/docs` endpoint
+// documented on the public /devs page) is not shipped in the open-source build.
+// This module reproduces the same contract — POST/GET /docs with snip /
+// encoded_snip / snip_uri[] / zip_uri / engine / main_document — on top of the
+// existing project-creation infrastructure, fetching external URLs through the
+// SSRF-guarded linked-url-proxy. It also serves the /devs documentation page.
+export default {
+  router: OpenInOverleafRouter,
+}


### PR DESCRIPTION
- backend: POST|GET /docs creates a project from snip / encoded_snip / snip_uri[] (+snip_name[]) / zip_uri / data: URLs, with engine and main_document; external URLs are fetched through linked-url-proxy (SSRF-guarded), capped at MAX_UPLOAD_SIZE with a 60s timeout
- frontend: /devs documentation page mirroring the official one, with live examples that open real projects on this server
- enable the module in settings.defaults.js

## Description

<!-- Goal of the pull request -->

Add devs page for ayakaleaf pro. Reference: http://www.overleaf.com/devs

<img width="100%" alt="devs page overview" src="https://github.com/user-attachments/assets/c87b2f4d-8fc7-455a-970f-261bafa68068" />

Full pages: 
<img width="100%" alt="devs page full screenshot" src="https://github.com/user-attachments/assets/eda05f3b-eb13-4baf-b4f9-e75abd1dda6d" />



## Related issues / Pull Requests

<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
