### PR TITLE
Fix(login-register): hide the 'or' divider on register when no SSO is enabled

### DIFF
--- a/services/web/modules/login-register/app/views/user/register.pug
+++ b/services/web/modules/login-register/app/views/user/register.pug
@@ -58,8 +58,9 @@ block content
 									)
 										span(data-ol-inflight="idle") #{translate("create_account")}
 										span(hidden data-ol-inflight="pending") #{translate("registering")}…
-							p.ciam-login-register-or-text-container
-								span.ciam-login-register-or-text #{translate("or")}
+							if (settings.ldap && settings.ldap.enable) || (settings.saml && settings.saml.enable) || (settings.oidc && settings.oidc.enable)
+								p.ciam-login-register-or-text-container
+									span.ciam-login-register-or-text #{translate("or")}
 							if settings.ldap && settings.ldap.enable
 								.actions(style='margin-top: 15px;')
 									a.button.btn-secondary.btn(


### PR DESCRIPTION
## Description
The ldap/saml/oidc buttons are each guarded by an if, but the 'or' separator above them was rendered unconditionally, so it showed on a plain email-only register page (issue #77). Guard it with the same condition already used in login.pug.

<!-- Goal of the pull request -->

## Related issues / Pull Requests
(issue https://github.com/ayaka-notes/ayakaleaf-pro/issues/77)
<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->

## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/main/CONTRIBUTING.md#contributor-license-agreement)
